### PR TITLE
[readme,all] remove random seed spec. Seeds have to be random -> thre…

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Macro commands for change of geometry, one material in the geometry,
 primary vertex generator, cross section bias factor (one each, neutron and muon), 
 bias split factor (integer >= 2)
 
-CLI for number of threads, macro file, output file name, random seed (for production runs)
+CLI for number of threads, macro file, output file name (for production runs)
 
 User Limits for run time optimization, use recommended benchmarking tool
 

--- a/examples/MuEvGen/muongenerator.cpp
+++ b/examples/MuEvGen/muongenerator.cpp
@@ -1,7 +1,6 @@
 #include <random>
 #include <cmath>
 #include <iostream>
-#include <chrono>
 
 class MuEnergy {
   // data members
@@ -64,8 +63,8 @@ int main() {
   double depth = 5.89; // Sudbury laboratory [km.w.e]
 
   // custom probability distributions
-  unsigned seed = std::chrono::system_clock::now().time_since_epoch().count();
-  std::mt19937 generator(seed); // explicit generator, time seed
+  std::random_device rd;
+  std::ranlux24 generator(rd()); // explicit generator
   pld_type ed(nw, lower_bound, upper_bound, MuEnergy(depth) );
   pld_type cosd(nw, nearhorizontal, fullcosangle, MuAngle(depth) );
 

--- a/include/WLGDActionInitialization.hh
+++ b/include/WLGDActionInitialization.hh
@@ -9,7 +9,7 @@
 class WLGDActionInitialization : public G4VUserActionInitialization
 {
   public:
-    WLGDActionInitialization(WLGDDetectorConstruction* det, G4int ival);
+    WLGDActionInitialization(WLGDDetectorConstruction* det);
     virtual ~WLGDActionInitialization();
 
     virtual void BuildForMaster() const;
@@ -17,7 +17,6 @@ class WLGDActionInitialization : public G4VUserActionInitialization
 
   private:
     WLGDDetectorConstruction* fDet;
-    G4int seed;
 };
 
 

--- a/include/WLGDPrimaryGeneratorAction.hh
+++ b/include/WLGDPrimaryGeneratorAction.hh
@@ -2,7 +2,6 @@
 #define WLGDPrimaryGeneratorAction_h 1
 
 // std c++ includes
-#include <random>
 #include <cmath>
 
 #include "G4VUserPrimaryGeneratorAction.hh"
@@ -77,7 +76,7 @@ class WLGDPrimaryGeneratorAction : public
 G4VUserPrimaryGeneratorAction
 {
   public:
-    WLGDPrimaryGeneratorAction(WLGDDetectorConstruction* det, G4int ival);
+    WLGDPrimaryGeneratorAction(WLGDDetectorConstruction* det);
     virtual ~WLGDPrimaryGeneratorAction();
     
     virtual void GeneratePrimaries(G4Event*);
@@ -89,8 +88,6 @@ G4VUserPrimaryGeneratorAction
   private:
     void DefineCommands();
 
-    std::mt19937 generator(0); // explicit std generator
-
     WLGDDetectorConstruction* fDetector;
 
     G4ParticleGun* fParticleGun;
@@ -98,7 +95,6 @@ G4VUserPrimaryGeneratorAction
     G4ParticleDefinition* fMuon;
 
     G4double fDepth;
-    G4int fseed;
 };
 
 #endif

--- a/src/WLGDActionInitialization.cc
+++ b/src/WLGDActionInitialization.cc
@@ -4,8 +4,8 @@
 #include "WLGDEventAction.hh"
 
 
-WLGDActionInitialization::WLGDActionInitialization(WLGDDetectorConstruction* det, G4int ival)
- : G4VUserActionInitialization(), fDet(det), seed(ival)
+WLGDActionInitialization::WLGDActionInitialization(WLGDDetectorConstruction* det)
+ : G4VUserActionInitialization(), fDet(det)
 {}
 
 
@@ -21,8 +21,8 @@ void WLGDActionInitialization::BuildForMaster() const
 
 void WLGDActionInitialization::Build() const
 {
-  // forward detector and seed
-  SetUserAction(new WLGDPrimaryGeneratorAction(fDet, seed));
+  // forward detector
+  SetUserAction(new WLGDPrimaryGeneratorAction(fDet));
   SetUserAction(new WLGDEventAction);
   SetUserAction(new WLGDRunAction);
 }  

--- a/src/WLGDPrimaryGeneratorAction.cc
+++ b/src/WLGDPrimaryGeneratorAction.cc
@@ -1,23 +1,28 @@
+// std
+#include <random>
+
+// us
 #include "WLGDPrimaryGeneratorAction.hh"
 #include "WLGDDetectorConstruction.hh"
 
+// geant
 #include "G4Event.hh"
 #include "G4ParticleGun.hh"
 #include "G4ParticleTable.hh"
 #include "G4ParticleDefinition.hh"
 #include "G4GenericMessenger.hh"
 #include "G4SystemOfUnits.hh"
-#include "Randomize.hh"
 
 
-WLGDPrimaryGeneratorAction::WLGDPrimaryGeneratorAction(WLGDDetectorConstruction* det, G4int ival)
+WLGDPrimaryGeneratorAction::WLGDPrimaryGeneratorAction(WLGDDetectorConstruction* det)
 : G4VUserPrimaryGeneratorAction(),     
   fDetector(det), 
   fParticleGun(nullptr), fMessenger(nullptr), 
   fMuon(nullptr), 
-  fDepth(0.0), fseed(ival) 
+  fDepth(0.0) 
 {
-  generator.seed(fseed); // re-initialize internal state with new seed
+  std::random_device rd; // random seed generator
+  std::ranlux24 generator(rd()); // std random engine
 
   G4int nofParticles = 1;
   fParticleGun  = new G4ParticleGun(nofParticles);

--- a/warwick-legend.cc
+++ b/warwick-legend.cc
@@ -35,7 +35,6 @@ void showHelp() {
   std::cout << "Command line option(s) help" << std::endl;
   std::cout << "\t -m , --macro <Geant4 macro filename> Default: None" << std::endl;
   std::cout << "\t -o , --outputFile <FULL PATH ROOT FILENAME> Default: lg.root" << std::endl;
-  std::cout << "\t -s , --seed <random seed for event generator> Default: 0" << std::endl;
   std::cout << "\t -t , --nthreads <number of threads to use> Default: 4" << std::endl;
 }
 
@@ -44,7 +43,6 @@ int main(int argc,char** argv)
 {
   // command line interface
   G4int nthreads = 4;
-  G4int seed = 0;
   G4String outputFileName;
   G4String macroName;
   GetOpt::GetOpt_pp ops(argc, argv);
@@ -57,7 +55,6 @@ int main(int argc,char** argv)
 
   ops >> GetOpt::Option('m', "macro", macroName, "");
   ops >> GetOpt::Option('o', "outputFile", outputFileName, "lg.root");
-  ops >> GetOpt::Option('s', "seed", seed, 0);
   ops >> GetOpt::Option('t', "nthreads", nthreads, 4);
 
   // GEANT4 code
@@ -94,7 +91,7 @@ int main(int argc,char** argv)
   runManager->SetUserInitialization(physicsList);
 
   // -- Set user action initialization class, forward random seed
-  auto actions = new WLGDActionInitialization(detector, seed);
+  auto actions = new WLGDActionInitialization(detector);
   runManager->SetUserInitialization(actions);
 
   // Initialize G4 kernel


### PR DESCRIPTION
Takes the random seed specification away since that can't work on threads, each constructing their primary event generator. Now all contained on single thread, lower weight random engine with a genuine random machine creating the seed for each thread independently.
All options to fix a seed are gone, in main, headers, source and readme.