### PR TITLE
Geo update

### DIFF
--- a/src/WLGDDetectorConstruction.cc
+++ b/src/WLGDDetectorConstruction.cc
@@ -81,7 +81,7 @@ void WLGDDetectorConstruction::ConstructSDandField()
         G4LogicalVolume* logicLar =
             G4LogicalVolumeStore::GetInstance()->GetVolume("Lar_log");
         G4LogicalVolume* logicULar =
-            G4LogicalVolumeStore::GetInstance()->GetVolume("Ular_log");
+            G4LogicalVolumeStore::GetInstance()->GetVolume("ULar_log");
         G4LogicalVolume* logicGe =
             G4LogicalVolumeStore::GetInstance()->GetVolume("Ge_log");
 
@@ -104,7 +104,7 @@ void WLGDDetectorConstruction::ConstructSDandField()
         G4LogicalVolume* logicLar =
             G4LogicalVolumeStore::GetInstance()->GetVolume("Lar_log");
         G4LogicalVolume* logicULar =
-            G4LogicalVolumeStore::GetInstance()->GetVolume("Ular_log");
+            G4LogicalVolumeStore::GetInstance()->GetVolume("ULar_log");
         G4LogicalVolume* logicGe =
             G4LogicalVolumeStore::GetInstance()->GetVolume("Ge_log");
 

--- a/src/WLGDDetectorConstruction.cc
+++ b/src/WLGDDetectorConstruction.cc
@@ -130,6 +130,8 @@ void WLGDDetectorConstruction::ConstructSDandField()
         // neutron bias
         biasnXS->AttachTo(logicGe);
     }
+
+    G4SDManager::GetSDMpointer()->SetVerboseLevel(0);
 }
 
 G4VPhysicalVolume* WLGDDetectorConstruction::SetupAlternative()
@@ -558,7 +560,7 @@ G4VPhysicalVolume* WLGDDetectorConstruction::SetupBaseline()
 
     auto      fGeLogical_px  = new G4LogicalVolume(geSolid, roiMat, "Ge_log");
     auto      fGePhysical_px =
-        new G4PVPlacement(0, G4ThreeVector(0. * cm, 0. * cm, 0. * cm), fGeLogical_px, "Ge_phys",
+        new G4PVPlacement(0, G4ThreeVector(0. * cm, 0. * cm, -cushift * cm), fGeLogical_px, "Ge_phys",
                           fUlarLogical_px, false, 0, true);
 
     //

--- a/src/WLGDDetectorConstruction.cc
+++ b/src/WLGDDetectorConstruction.cc
@@ -234,8 +234,8 @@ G4VPhysicalVolume* WLGDDetectorConstruction::SetupAlternative()
         new G4Box("Cavern", hallhside * cm, hallhside * cm, hallhside * cm);
     auto fHallLogical = new G4LogicalVolume(hallSolid, airMat, "Hall_log");
     auto fHallPhysical =
-        new G4PVPlacement(0, G4ThreeVector(0., 0., offset * cm), fHallLogical,
-                          "Hall_phys", fCavernLogical, false, 0);
+        new G4PVPlacement(0, G4ThreeVector(0., 0., stone * cm), fHallLogical,
+                          "Hall_phys", fCavernLogical, false, 0, true);
 
     //
     // Tank
@@ -244,7 +244,7 @@ G4VPhysicalVolume* WLGDDetectorConstruction::SetupAlternative()
         new G4Box("Tank", tankhside * cm, tankhside * cm, tankhside * cm);
     auto fTankLogical  = new G4LogicalVolume(tankSolid, steelMat, "Tank_log");
     auto fTankPhysical = new G4PVPlacement(0, G4ThreeVector(), fTankLogical, "Tank_phys",
-                                           fHallLogical, false, 0);
+                                           fHallLogical, false, 0, true);
 
     //
     // Insulator
@@ -254,7 +254,7 @@ G4VPhysicalVolume* WLGDDetectorConstruction::SetupAlternative()
                   (tankhside - outerwall) * cm);
     auto fPuLogical  = new G4LogicalVolume(puSolid, puMat, "Pu_log");
     auto fPuPhysical = new G4PVPlacement(0, G4ThreeVector(), fPuLogical, "Pu_phys",
-                                         fTankLogical, false, 0);
+                                         fTankLogical, false, 0, true);
 
     //
     // Membrane
@@ -265,7 +265,7 @@ G4VPhysicalVolume* WLGDDetectorConstruction::SetupAlternative()
                   (tankhside - outerwall - insulation) * cm);
     auto fMembraneLogical  = new G4LogicalVolume(membraneSolid, steelMat, "Membrane_log");
     auto fMembranePhysical = new G4PVPlacement(0, G4ThreeVector(), fMembraneLogical,
-                                               "Membrane_phys", fPuLogical, false, 0);
+                                               "Membrane_phys", fPuLogical, false, 0, true);
 
     //
     // LAr
@@ -276,60 +276,67 @@ G4VPhysicalVolume* WLGDDetectorConstruction::SetupAlternative()
                                           fMembraneLogical, false, 0, true);
 
     //
-    // Copper tubes
-    //
+    // copper tubes, hollow cylinder shell
+    // 
     G4VSolid* copperSolid =
-        new G4Tubs("Copper", 0.0 * cm, curad * cm, cuhheight * cm, 0.0, CLHEP::twopi);
-    auto fCopperLogical = new G4LogicalVolume(copperSolid, copperMat, "Copper_log");
-    auto fCuPhysical_px =
-        new G4PVPlacement(0, G4ThreeVector(ringrad * cm, 0., cushift * cm),
-                          fCopperLogical, "Copper_phys1", fLarLogical, false, 0, true);
-    auto fCuPhysical_py =
-        new G4PVPlacement(0, G4ThreeVector(0., ringrad * cm, cushift * cm),
-                          fCopperLogical, "Copper_phys2", fLarLogical, false, 1, true);
-    auto fCuPhysical_mx =
-        new G4PVPlacement(0, G4ThreeVector(-ringrad * cm, 0., cushift * cm),
-                          fCopperLogical, "Copper_phys3", fLarLogical, false, 2, true);
-    auto fCuPhysical_my =
-        new G4PVPlacement(0, G4ThreeVector(0., -ringrad * cm, cushift * cm),
-                          fCopperLogical, "Copper_phys4", fLarLogical, false, 3, true);
-
-    //
-    // ULAr bath
+        new G4Tubs("Copper", (curad - copper) * cm, curad * cm, cuhheight * cm, 0.0, CLHEP::twopi);
+    
+    //                    
+    // ULAr bath, solid cylinder
     //
     G4VSolid* ularSolid    = new G4Tubs("ULar", 0.0 * cm, (curad - copper) * cm,
                                      cuhheight * cm, 0.0, CLHEP::twopi);
-    auto      fUlarLogical = new G4LogicalVolume(ularSolid, larMat, "ULar_log");
-    auto      fUlarPhysical_px =
-        new G4PVPlacement(0, G4ThreeVector(ringrad * cm, 0., cushift * cm), fUlarLogical,
-                          "ULar_phys1", fCopperLogical, false, 0, true);
-    auto fUlarPhysical_py =
-        new G4PVPlacement(0, G4ThreeVector(0., ringrad * cm, cushift * cm), fUlarLogical,
-                          "ULar_phys2", fCopperLogical, false, 1, true);
-    auto fUlarPhysical_mx =
-        new G4PVPlacement(0, G4ThreeVector(-ringrad * cm, 0., cushift * cm), fUlarLogical,
-                          "ULar_phys3", fCopperLogical, false, 2, true);
-    auto fUlarPhysical_my =
-        new G4PVPlacement(0, G4ThreeVector(0., -ringrad * cm, cushift * cm), fUlarLogical,
-                          "ULar_phys4", fCopperLogical, false, 3, true);
-
+    
     //
-    // Germanium
+    // Germanium, solid cylinder
     //
     G4VSolid* geSolid    = new G4Tubs("ROI", 0.0 * cm, roiradius * cm, roihalfheight * cm,
                                    0.0, CLHEP::twopi);
-    auto      fGeLogical = new G4LogicalVolume(geSolid, roiMat, "Ge_log");
-    auto      fGePhysical_px =
-        new G4PVPlacement(0, G4ThreeVector(ringrad * cm, 0., 0.), fGeLogical, "Ge_phys1",
+    
+    // tower; logical volumes
+    auto fCopperLogical = new G4LogicalVolume(copperSolid, copperMat, "Copper_log");
+    auto  fUlarLogical  = new G4LogicalVolume(ularSolid, larMat, "ULar_log");
+    auto    fGeLogical  = new G4LogicalVolume(geSolid, roiMat, "Ge_log");
+      
+    // placements
+    new G4PVPlacement(0, G4ThreeVector(ringrad * cm, 0., cushift * cm),
+                          fCopperLogical, "Copper_phys", fLarLogical, false, 0, true);
+                                     
+    new G4PVPlacement(0, G4ThreeVector(ringrad * cm, 0., cushift * cm), fUlarLogical,
+                          "ULar_phys", fLarLogical, false, 0, true);
+    
+    new G4PVPlacement(0, G4ThreeVector(0. * cm, 0. * cm, -cushift * cm), fGeLogical, "Ge_phys",
                           fUlarLogical, false, 0, true);
-    auto fGePhysical_py =
-        new G4PVPlacement(0, G4ThreeVector(0., ringrad * cm, 0.), fGeLogical, "Ge_phys2",
+                                   
+    // tower 2
+    new G4PVPlacement(0, G4ThreeVector(0., ringrad * cm, cushift * cm),
+                          fCopperLogical, "Copper_phys2", fLarLogical, false, 1, true);
+    
+    new G4PVPlacement(0, G4ThreeVector(0., ringrad * cm, cushift * cm), fUlarLogical,
+                          "ULar_phys2", fLarLogical, false, 1, true);
+    
+    new G4PVPlacement(0, G4ThreeVector(0. * cm, 0. * cm, -cushift * cm), fGeLogical, "Ge_phys2",
                           fUlarLogical, false, 1, true);
-    auto fGePhysical_mx =
-        new G4PVPlacement(0, G4ThreeVector(-ringrad * cm, 0., 0.), fGeLogical, "Ge_phys3",
+                                     
+
+    // tower 3
+    new G4PVPlacement(0, G4ThreeVector(-ringrad * cm, 0., cushift * cm),
+                          fCopperLogical, "Copper_phys3", fLarLogical, false, 2, true);
+    
+    new G4PVPlacement(0, G4ThreeVector(-ringrad * cm, 0., cushift * cm), fUlarLogical,
+                          "ULar_phys3", fLarLogical, false, 2, true);
+    
+    new G4PVPlacement(0, G4ThreeVector(0. * cm, 0. * cm, -cushift * cm), fGeLogical, "Ge_phys3",
                           fUlarLogical, false, 2, true);
-    auto fGePhysical_my =
-        new G4PVPlacement(0, G4ThreeVector(0., -ringrad * cm, 0.), fGeLogical, "Ge_phys4",
+    
+    // tower 4
+    new G4PVPlacement(0, G4ThreeVector(0., -ringrad * cm, cushift * cm),
+                          fCopperLogical, "Copper_phys4", fLarLogical, false, 3, true);
+    
+    new G4PVPlacement(0, G4ThreeVector(0., -ringrad * cm, cushift * cm), fUlarLogical,
+                          "ULar_phys4", fLarLogical, false, 3, true);
+    
+    new G4PVPlacement(0, G4ThreeVector(0. * cm, 0. * cm, -cushift * cm), fGeLogical, "Ge_phys4",
                           fUlarLogical, false, 3, true);
 
     //
@@ -530,38 +537,67 @@ G4VPhysicalVolume* WLGDDetectorConstruction::SetupBaseline()
                           fBotLogical, "Bot_phys", fWaterLogical, false, 0, true);
 
     //
-    // copper tubes
+    // copper tubes, hollow cylinder shell
     //
     G4VSolid* copperSolid =
         new G4Tubs("Copper", (curad - copper) * cm, curad * cm, cuhheight * cm, 0.0, CLHEP::twopi);
 
     //
-    // ULAr bath
+    // ULAr bath, solid cylinder
     //
     G4VSolid* ularSolid    = new G4Tubs("ULar", 0.0 * cm, (curad - copper) * cm,
                                      cuhheight * cm, 0.0, CLHEP::twopi);
 
     //
-    // Germanium
+    // Germanium, solid cylinder
     //
     G4VSolid* geSolid    = new G4Tubs("ROI", 0.0 * cm, roiradius * cm, roihalfheight * cm,
                                    0.0, CLHEP::twopi);
 
-    // tower 1
-    auto fCopperLogical_px = new G4LogicalVolume(copperSolid, copperMat, "Copper_log");
-    auto fCuPhysical_px    =
-        new G4PVPlacement(0, G4ThreeVector(ringrad * cm, 0., cushift * cm),
-                          fCopperLogical_px, "Copper_phys", fLarLogical, false, 0, true);
+    // tower; logical volumes
+    auto fCopperLogical = new G4LogicalVolume(copperSolid, copperMat, "Copper_log");
+    auto  fUlarLogical  = new G4LogicalVolume(ularSolid, larMat, "ULar_log");
+    auto    fGeLogical  = new G4LogicalVolume(geSolid, roiMat, "Ge_log");
 
-    auto      fUlarLogical_px  = new G4LogicalVolume(ularSolid, larMat, "ULar_log");
-    auto      fUlarPhysical_px =
-        new G4PVPlacement(0, G4ThreeVector(ringrad * cm, 0., cushift * cm), fUlarLogical_px,
+    // placements
+    new G4PVPlacement(0, G4ThreeVector(ringrad * cm, 0., cushift * cm),
+                          fCopperLogical, "Copper_phys", fLarLogical, false, 0, true);
+
+    new G4PVPlacement(0, G4ThreeVector(ringrad * cm, 0., cushift * cm), fUlarLogical,
                           "ULar_phys", fLarLogical, false, 0, true);  
 
-    auto      fGeLogical_px  = new G4LogicalVolume(geSolid, roiMat, "Ge_log");
-    auto      fGePhysical_px =
-        new G4PVPlacement(0, G4ThreeVector(0. * cm, 0. * cm, -cushift * cm), fGeLogical_px, "Ge_phys",
-                          fUlarLogical_px, false, 0, true);
+    new G4PVPlacement(0, G4ThreeVector(0. * cm, 0. * cm, -cushift * cm), fGeLogical, "Ge_phys",
+                          fUlarLogical, false, 0, true);
+
+    // tower 2
+    new G4PVPlacement(0, G4ThreeVector(0., ringrad * cm, cushift * cm),
+                          fCopperLogical, "Copper_phys2", fLarLogical, false, 1, true);
+    
+    new G4PVPlacement(0, G4ThreeVector(0., ringrad * cm, cushift * cm), fUlarLogical,
+                          "ULar_phys2", fLarLogical, false, 1, true);
+    
+    new G4PVPlacement(0, G4ThreeVector(0. * cm, 0. * cm, -cushift * cm), fGeLogical, "Ge_phys2",
+                          fUlarLogical, false, 1, true);
+
+    // tower 3
+    new G4PVPlacement(0, G4ThreeVector(-ringrad * cm, 0., cushift * cm),
+                          fCopperLogical, "Copper_phys3", fLarLogical, false, 2, true);
+    
+    new G4PVPlacement(0, G4ThreeVector(-ringrad * cm, 0., cushift * cm), fUlarLogical,   
+                          "ULar_phys3", fLarLogical, false, 2, true);
+    
+    new G4PVPlacement(0, G4ThreeVector(0. * cm, 0. * cm, -cushift * cm), fGeLogical, "Ge_phys3",
+                          fUlarLogical, false, 2, true);
+
+    // tower 4
+    new G4PVPlacement(0, G4ThreeVector(0., -ringrad * cm, cushift * cm),
+                          fCopperLogical, "Copper_phys4", fLarLogical, false, 3, true);
+    
+    new G4PVPlacement(0, G4ThreeVector(0., -ringrad * cm, cushift * cm), fUlarLogical,   
+                          "ULar_phys4", fLarLogical, false, 3, true);
+    
+    new G4PVPlacement(0, G4ThreeVector(0. * cm, 0. * cm, -cushift * cm), fGeLogical, "Ge_phys4",
+                          fUlarLogical, false, 3, true);
 
     //
     // Visualization attributes
@@ -587,9 +623,9 @@ G4VPhysicalVolume* WLGDDetectorConstruction::SetupBaseline()
     fCinnLogical->SetVisAttributes(blueVisAtt);
     fLidLogical->SetVisAttributes(blueVisAtt);
     fBotLogical->SetVisAttributes(blueVisAtt);
-    fCopperLogical_px->SetVisAttributes(greenVisAtt);
-    fUlarLogical_px->SetVisAttributes(greyVisAtt);
-    fGeLogical_px->SetVisAttributes(redVisAtt);
+    fCopperLogical->SetVisAttributes(greenVisAtt);
+    fUlarLogical->SetVisAttributes(greyVisAtt);
+    fGeLogical->SetVisAttributes(redVisAtt);
 
     return fWorldPhysical;
 }

--- a/src/WLGDDetectorConstruction.cc
+++ b/src/WLGDDetectorConstruction.cc
@@ -203,7 +203,7 @@ G4VPhysicalVolume* WLGDDetectorConstruction::SetupAlternative()
     G4double larside =
         tankhside - outerwall - insulation - innerwall;  // cube side of LAr volume
 
-    fvertexZ = worldside - 0.1;  // max vertex height
+    fvertexZ = (worldside - 0.1) * cm;  // max vertex height
     fmaxrad  = fvertexZ;         // max vertex circle radius
 
     // Volumes for this geometry
@@ -421,8 +421,8 @@ G4VPhysicalVolume* WLGDDetectorConstruction::SetupBaseline()
     G4double roiradius     = 25.0;   // detector region diam 50 cm
     G4double roihalfheight = 11.97;  // detector region height 24 cm
 
-    fvertexZ = hallhheight + stone + offset;
-    fmaxrad  = hallrad + stone;
+    fvertexZ = (hallhheight + stone + offset) * cm;
+    fmaxrad  = (hallrad + stone) * cm;
 
     // Volumes for this geometry
 

--- a/src/WLGDDetectorConstruction.cc
+++ b/src/WLGDDetectorConstruction.cc
@@ -125,16 +125,25 @@ G4VPhysicalVolume* WLGDDetectorConstruction::SetupAlternative()
     G4Material* worldMaterial =
         G4NistManager::Instance()->FindOrBuildMaterial("G4_Galactic");
     G4Material* larMat = G4NistManager::Instance()->FindOrBuildMaterial("G4_lAr");
-    G4Material* concreteWallMat =
-        G4NistManager::Instance()->FindOrBuildMaterial("G4_CONCRETE");
     G4Material* airMat = G4NistManager::Instance()->FindOrBuildMaterial("G4_AIR");
     G4Material* steelMat =
         G4NistManager::Instance()->FindOrBuildMaterial("G4_STAINLESS-STEEL");
     G4Material* copperMat = G4NistManager::Instance()->FindOrBuildMaterial("G4_Cu");
 
-    auto H     = new G4Element("Hydrogen", "H", 1., 1.00794 * g / mole);
     auto C     = new G4Element("Carbon", "C", 6., 12.011 * g / mole);
     auto O     = new G4Element("Oxygen", "O", 8., 16.00 * g / mole);
+    auto Ca    = new G4Element("Calcium", "Ca", 20., 40.08 * g / mole);
+    auto Mg    = new G4Element("Magnesium", "Mg", 12., 24.31 * g / mole);
+
+    // Standard Rock definition, similar to Gran Sasso rock
+    // with density from PDG report
+    auto stdRock = new G4Material("StdRock", 2.65*g/cm3, 4);
+    stdRock->AddElement(O,  52.0*perCent);
+    stdRock->AddElement(Ca, 27.0*perCent);
+    stdRock->AddElement(C,  12.0*perCent);
+    stdRock->AddElement(Mg,  9.0*perCent);
+
+    auto H     = new G4Element("Hydrogen", "H", 1., 1.00794 * g / mole);
     auto N     = new G4Element("Nitrogen", "N", 7., 14.00 * g / mole);
     auto puMat = new G4Material("polyurethane", 0.3 * g / cm3, 4);  // high density foam
     puMat->AddElement(H, 16);
@@ -199,7 +208,7 @@ G4VPhysicalVolume* WLGDDetectorConstruction::SetupAlternative()
     //
     G4VSolid* cavernSolid = new G4Box("Cavern", (hallhside + stone) * cm,
                                       (hallhside + stone) * cm, (hallhside + stone) * cm);
-    auto fCavernLogical = new G4LogicalVolume(cavernSolid, concreteWallMat, "Cavern_log");
+    auto fCavernLogical = new G4LogicalVolume(cavernSolid, stdRock, "Cavern_log");
     auto fCavernPhysical =
         new G4PVPlacement(0, G4ThreeVector(0., 0., offset * cm), fCavernLogical,
                           "Cavern_phys", fWorldLogical, false, 0);
@@ -342,15 +351,26 @@ G4VPhysicalVolume* WLGDDetectorConstruction::SetupBaseline()
     G4Material* worldMaterial =
         G4NistManager::Instance()->FindOrBuildMaterial("G4_Galactic");
     G4Material* larMat = G4NistManager::Instance()->FindOrBuildMaterial("G4_lAr");
-    G4Material* concreteWallMat =
-        G4NistManager::Instance()->FindOrBuildMaterial("G4_CONCRETE");
     G4Material* airMat   = G4NistManager::Instance()->FindOrBuildMaterial("G4_AIR");
     G4Material* waterMat = G4NistManager::Instance()->FindOrBuildMaterial("G4_WATER");
     G4Material* steelMat =
         G4NistManager::Instance()->FindOrBuildMaterial("G4_STAINLESS-STEEL");
     G4Material* copperMat = G4NistManager::Instance()->FindOrBuildMaterial("G4_Cu");
 
-    // enriched Germanium from isotopes
+    auto C     = new G4Element("Carbon", "C", 6., 12.011 * g / mole);
+    auto O     = new G4Element("Oxygen", "O", 8., 16.00 * g / mole);
+    auto Ca    = new G4Element("Calcium", "Ca", 20., 40.08 * g / mole);
+    auto Mg    = new G4Element("Magnesium", "Mg", 12., 24.31 * g / mole);
+    
+    // Standard Rock definition, similar to Gran Sasso rock
+    // with density from PDG report
+    auto stdRock = new G4Material("StdRock", 2.65*g/cm3, 4);
+    stdRock->AddElement(O,  52.0*perCent);
+    stdRock->AddElement(Ca, 27.0*perCent);
+    stdRock->AddElement(C,  12.0*perCent);
+    stdRock->AddElement(Mg,  9.0*perCent);
+
+   // enriched Germanium from isotopes
     auto Ge_74 = new G4Isotope("Ge74", 32, 74, 74.0 * g / mole);
     auto Ge_76 = new G4Isotope("Ge76", 32, 76, 76.0 * g / mole);
 
@@ -409,7 +429,7 @@ G4VPhysicalVolume* WLGDDetectorConstruction::SetupBaseline()
     //
     G4VSolid* cavernSolid = new G4Tubs("Cavern", 0.0 * cm, (hallrad + stone) * cm,
                                        (hallhheight + stone) * cm, 0.0, CLHEP::twopi);
-    auto fCavernLogical = new G4LogicalVolume(cavernSolid, concreteWallMat, "Cavern_log");
+    auto fCavernLogical = new G4LogicalVolume(cavernSolid, stdRock, "Cavern_log");
     auto fCavernPhysical =
         new G4PVPlacement(0, G4ThreeVector(0., 0., offset * cm), fCavernLogical,
                           "Cavern_phys", fWorldLogical, false, 0);

--- a/src/WLGDDetectorConstruction.cc
+++ b/src/WLGDDetectorConstruction.cc
@@ -315,9 +315,6 @@ G4VPhysicalVolume* WLGDDetectorConstruction::SetupAlternative()
     new G4PVPlacement(0, G4ThreeVector(0., ringrad * cm, cushift * cm), fUlarLogical,
                           "ULar_phys2", fLarLogical, false, 1, true);
     
-    new G4PVPlacement(0, G4ThreeVector(0. * cm, 0. * cm, -cushift * cm), fGeLogical, "Ge_phys2",
-                          fUlarLogical, false, 1, true);
-                                     
 
     // tower 3
     new G4PVPlacement(0, G4ThreeVector(-ringrad * cm, 0., cushift * cm),
@@ -326,9 +323,6 @@ G4VPhysicalVolume* WLGDDetectorConstruction::SetupAlternative()
     new G4PVPlacement(0, G4ThreeVector(-ringrad * cm, 0., cushift * cm), fUlarLogical,
                           "ULar_phys3", fLarLogical, false, 2, true);
     
-    new G4PVPlacement(0, G4ThreeVector(0. * cm, 0. * cm, -cushift * cm), fGeLogical, "Ge_phys3",
-                          fUlarLogical, false, 2, true);
-    
     // tower 4
     new G4PVPlacement(0, G4ThreeVector(0., -ringrad * cm, cushift * cm),
                           fCopperLogical, "Copper_phys4", fLarLogical, false, 3, true);
@@ -336,9 +330,6 @@ G4VPhysicalVolume* WLGDDetectorConstruction::SetupAlternative()
     new G4PVPlacement(0, G4ThreeVector(0., -ringrad * cm, cushift * cm), fUlarLogical,
                           "ULar_phys4", fLarLogical, false, 3, true);
     
-    new G4PVPlacement(0, G4ThreeVector(0. * cm, 0. * cm, -cushift * cm), fGeLogical, "Ge_phys4",
-                          fUlarLogical, false, 3, true);
-
     //
     // Visualization attributes
     //
@@ -576,9 +567,6 @@ G4VPhysicalVolume* WLGDDetectorConstruction::SetupBaseline()
     new G4PVPlacement(0, G4ThreeVector(0., ringrad * cm, cushift * cm), fUlarLogical,
                           "ULar_phys2", fLarLogical, false, 1, true);
     
-    new G4PVPlacement(0, G4ThreeVector(0. * cm, 0. * cm, -cushift * cm), fGeLogical, "Ge_phys2",
-                          fUlarLogical, false, 1, true);
-
     // tower 3
     new G4PVPlacement(0, G4ThreeVector(-ringrad * cm, 0., cushift * cm),
                           fCopperLogical, "Copper_phys3", fLarLogical, false, 2, true);
@@ -586,9 +574,6 @@ G4VPhysicalVolume* WLGDDetectorConstruction::SetupBaseline()
     new G4PVPlacement(0, G4ThreeVector(-ringrad * cm, 0., cushift * cm), fUlarLogical,   
                           "ULar_phys3", fLarLogical, false, 2, true);
     
-    new G4PVPlacement(0, G4ThreeVector(0. * cm, 0. * cm, -cushift * cm), fGeLogical, "Ge_phys3",
-                          fUlarLogical, false, 2, true);
-
     // tower 4
     new G4PVPlacement(0, G4ThreeVector(0., -ringrad * cm, cushift * cm),
                           fCopperLogical, "Copper_phys4", fLarLogical, false, 3, true);
@@ -596,8 +581,6 @@ G4VPhysicalVolume* WLGDDetectorConstruction::SetupBaseline()
     new G4PVPlacement(0, G4ThreeVector(0., -ringrad * cm, cushift * cm), fUlarLogical,   
                           "ULar_phys4", fLarLogical, false, 3, true);
     
-    new G4PVPlacement(0, G4ThreeVector(0. * cm, 0. * cm, -cushift * cm), fGeLogical, "Ge_phys4",
-                          fUlarLogical, false, 3, true);
 
     //
     // Visualization attributes

--- a/src/WLGDPrimaryGeneratorAction.cc
+++ b/src/WLGDPrimaryGeneratorAction.cc
@@ -82,7 +82,7 @@ void WLGDPrimaryGeneratorAction::GeneratePrimaries(G4Event* event)
     G4double vx      = maxrad * std::cos(phi);
     G4double vy      = maxrad * std::sin(phi);
 
-    fParticleGun->SetParticlePosition(G4ThreeVector(vx, vy, zvertex));
+    fParticleGun->SetParticlePosition(G4ThreeVector(vx, vy, zvertex - 1.0*cm));
 
     fParticleGun->GeneratePrimaryVertex(event);
 }

--- a/test0.mac
+++ b/test0.mac
@@ -1,0 +1,6 @@
+# minimal command set test
+/run/verbose 2
+/tracking/verbose 1
+
+/run/beamOn 4
+

--- a/test0.mac
+++ b/test0.mac
@@ -1,6 +1,13 @@
 # minimal command set test
+/run/initialize
+
+# verbose
 /run/verbose 2
 /tracking/verbose 1
 
+# set default cut
+/run/setCut 1.0 cm
+
+# start
 /run/beamOn 4
 


### PR DESCRIPTION
This updates the geometry. Overlap checking is enabled and geometry mistakes are taken out whch prevented building and running the app. A first test macro with four events and massive text output (last was 25Mb) is added. Further geometry checking is required to see if the 4 detector towers really represent the geometry in storage as intended. The alternative geometry is untested so far. Another test macro, exercising the new command definitions would be needed for that.
The text output also strengthens the case to put in UserLimits to restrict e- and gamma transport.