### PR TITLE
Userlimits

### DIFF
--- a/src/WLGDDetectorConstruction.cc
+++ b/src/WLGDDetectorConstruction.cc
@@ -20,6 +20,7 @@
 
 #include "WLGDBiasMultiParticleChangeCrossSection.hh"
 
+#include "G4UserLimits.hh"
 #include "G4PhysicalConstants.hh"
 #include "G4SystemOfUnits.hh"
 
@@ -204,7 +205,7 @@ G4VPhysicalVolume* WLGDDetectorConstruction::SetupAlternative()
         tankhside - outerwall - insulation - innerwall;  // cube side of LAr volume
 
     fvertexZ = (worldside - 0.1) * cm;  // max vertex height
-    fmaxrad  = fvertexZ;         // max vertex circle radius
+    fmaxrad  = fvertexZ - stone * cm;   // max vertex circle radius
 
     // Volumes for this geometry
 
@@ -331,6 +332,14 @@ G4VPhysicalVolume* WLGDDetectorConstruction::SetupAlternative()
                           "ULar_phys4", fLarLogical, false, 3, true);
     
     //
+    // User limits
+    //
+    G4double maxTime = 1 * ms; // affects long-lived neutrons
+    G4UserLimits* outerlimit = new G4UserLimits(DBL_MAX,DBL_MAX,maxTime);
+    fCavernLogical->SetUserLimits(outerlimit);
+    fLarLogical->SetUserLimits(outerlimit);
+
+    //
     // Visualization attributes
     //
     fWorldLogical->SetVisAttributes(G4VisAttributes::GetInvisible());
@@ -422,7 +431,7 @@ G4VPhysicalVolume* WLGDDetectorConstruction::SetupBaseline()
     G4double roihalfheight = 11.97;  // detector region height 24 cm
 
     fvertexZ = (hallhheight + stone + offset) * cm;
-    fmaxrad  = (hallrad + stone) * cm;
+    fmaxrad  = hallrad * cm;
 
     // Volumes for this geometry
 
@@ -581,6 +590,15 @@ G4VPhysicalVolume* WLGDDetectorConstruction::SetupBaseline()
     new G4PVPlacement(0, G4ThreeVector(0., -ringrad * cm, cushift * cm), fUlarLogical,   
                           "ULar_phys4", fLarLogical, false, 3, true);
     
+
+    //
+    // User limits
+    //
+    G4double maxTime = 1 * ms; // affects long-lived neutrons
+    G4UserLimits* outerlimit = new G4UserLimits(DBL_MAX,DBL_MAX,maxTime);
+    fCavernLogical->SetUserLimits(outerlimit);
+    fWaterLogical->SetUserLimits(outerlimit);
+    fLarLogical->SetUserLimits(outerlimit);
 
     //
     // Visualization attributes

--- a/src/WLGDDetectorConstruction.cc
+++ b/src/WLGDDetectorConstruction.cc
@@ -235,7 +235,7 @@ G4VPhysicalVolume* WLGDDetectorConstruction::SetupAlternative()
         new G4Box("Cavern", hallhside * cm, hallhside * cm, hallhside * cm);
     auto fHallLogical = new G4LogicalVolume(hallSolid, airMat, "Hall_log");
     auto fHallPhysical =
-        new G4PVPlacement(0, G4ThreeVector(0., 0., stone * cm), fHallLogical,
+        new G4PVPlacement(0, G4ThreeVector(0., 0., -stone * cm), fHallLogical,
                           "Hall_phys", fCavernLogical, false, 0, true);
 
     //
@@ -244,7 +244,7 @@ G4VPhysicalVolume* WLGDDetectorConstruction::SetupAlternative()
     G4VSolid* tankSolid =
         new G4Box("Tank", tankhside * cm, tankhside * cm, tankhside * cm);
     auto fTankLogical  = new G4LogicalVolume(tankSolid, steelMat, "Tank_log");
-    auto fTankPhysical = new G4PVPlacement(0, G4ThreeVector(), fTankLogical, "Tank_phys",
+    auto fTankPhysical = new G4PVPlacement(0, G4ThreeVector(0., 0., -stone * cm), fTankLogical, "Tank_phys",
                                            fHallLogical, false, 0, true);
 
     //
@@ -462,7 +462,7 @@ G4VPhysicalVolume* WLGDDetectorConstruction::SetupBaseline()
         new G4Tubs("Hall", 0.0 * cm, hallrad * cm, hallhheight * cm, 0.0, CLHEP::twopi);
     auto fHallLogical = new G4LogicalVolume(hallSolid, airMat, "Hall_log");
     auto fHallPhysical =
-        new G4PVPlacement(0, G4ThreeVector(0., 0., stone * cm), fHallLogical,
+        new G4PVPlacement(0, G4ThreeVector(0., 0., -stone * cm), fHallLogical,
                           "Hall_phys", fCavernLogical, false, 0, true);
 
     //
@@ -472,7 +472,7 @@ G4VPhysicalVolume* WLGDDetectorConstruction::SetupBaseline()
         new G4Cons("Tank", 0.0 * cm, (tankrad + tankwallbot) * cm, 0.0 * cm,
                    (tankrad + tankwalltop) * cm, tankhheight * cm, 0.0, CLHEP::twopi);
     auto fTankLogical  = new G4LogicalVolume(tankSolid, steelMat, "Tank_log");
-    auto fTankPhysical = new G4PVPlacement(0, G4ThreeVector(), fTankLogical, "Tank_phys",
+    auto fTankPhysical = new G4PVPlacement(0, G4ThreeVector(0., 0., -stone * cm), fTankLogical, "Tank_phys",
                                            fHallLogical, false, 0, true);
 
     //

--- a/src/WLGDPrimaryGeneratorAction.cc
+++ b/src/WLGDPrimaryGeneratorAction.cc
@@ -77,10 +77,10 @@ void WLGDPrimaryGeneratorAction::GeneratePrimaries(G4Event* event)
 
     // position, top of world, sample circle uniformly
     G4double zvertex = fDetector->GetWorldSizeZ();   // inline on WLGDDetectorConstruction
-    G4double maxrad  = fDetector->GetWorldExtent();  // --"--
+    G4double radius  = fDetector->GetWorldExtent() * rndm(generator);  // fraction of max
     phi              = CLHEP::twopi * rndm(generator);  // another random angle
-    G4double vx      = maxrad * std::cos(phi);
-    G4double vy      = maxrad * std::sin(phi);
+    G4double vx      = radius * std::cos(phi);
+    G4double vy      = radius * std::sin(phi);
 
     fParticleGun->SetParticlePosition(G4ThreeVector(vx, vy, zvertex - 1.0*cm));
 

--- a/test0.mac
+++ b/test0.mac
@@ -8,6 +8,9 @@
 # set default cut
 /run/setCut 1.0 cm
 
+# lab depth [km.w.e.]
+/WLGD/generator/depth 5.89
+
 # start
 /run/beamOn 4
 

--- a/warwick-legend.cc
+++ b/warwick-legend.cc
@@ -22,6 +22,7 @@
 
 // Geant4
 #include "G4GenericBiasingPhysics.hh"
+#include "G4NeutronTrackingCut.hh"
 #include "G4Threading.hh"
 #include "G4UImanager.hh"
 #include "Shielding.hh"
@@ -70,9 +71,11 @@ int main(int argc, char** argv)
     auto detector = new WLGDDetectorConstruction;
     runManager->SetUserInitialization(detector);
 
+    // -- set user physics list
     auto physicsList = new Shielding;
+    physicsList->RegisterPhysics(new G4NeutronTrackingCut()); // allow G4UserLimits
 
-    // -- Setup biasing, first for neutrons, again for muons
+    // - Setup biasing, first for neutrons, again for muons
     G4GenericBiasingPhysics* biasingPhysics = new G4GenericBiasingPhysics();
 
     G4String              pname = "nCapture";  // neutron capture process name


### PR DESCRIPTION
Added UserLimits, as a trial a maximum time limit for neutrons, applied to the cavern, water volume and LAr volume. Challenge is how to link those G4UserLimits attaching to logical volumes to particles and the pre-defined physics list. Seems to work though.
Changed mistakes in the outer volumes in the geometry in positioning. All fine for the baseline geometry. Alternative geometry not tested yet.
Introduced first WLGD macro commnd on depth which works well. Default depth of 0.0 gives much lower energy muons as expected with little penetration into the geometry. High energy muons in test runs create neutrons (with biased muonNuclear) which appear to be killed earlier while thermalizing in water, as expected for a max time cut (set to 1 ms).