### PR TITLE
Output

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ add_executable(warwick-legend
   src/WLGDEventAction.cc
   src/WLGDPrimaryGeneratorAction.cc
   src/WLGDPSLocation.cc
+  src/WLGDPSTime.cc
   src/WLGDRunAction.cc)
 target_include_directories(warwick-legend PRIVATE ${PROJECT_SOURCE_DIR}/include)
 target_link_libraries(warwick-legend PRIVATE ${Geant4_LIBRARIES})

--- a/include/WLGDPSLocation.hh
+++ b/include/WLGDPSLocation.hh
@@ -8,7 +8,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 // Description:
 //   This is a primitive scorer class for scoring energy deposit location
-//   at termination of the track.
+//   at every collision = non boundary step, of the track.
 //
 ///////////////////////////////////////////////////////////////////////////////
 
@@ -33,7 +33,6 @@ public:
 
 private:
     G4int                      HCID;
-    G4int                      fcounter;
     G4THitsMap<G4ThreeVector>* EvtMap;
 };
 #endif

--- a/include/WLGDPSTime.hh
+++ b/include/WLGDPSTime.hh
@@ -1,0 +1,36 @@
+#ifndef WLGDPSTime_h
+#define WLGDPSTime_h 1
+
+#include "G4THitsMap.hh"
+#include "G4VPrimitiveScorer.hh"
+
+////////////////////////////////////////////////////////////////////////////////
+// Description:
+//   This is a primitive scorer class for scoring global track time
+//
+///////////////////////////////////////////////////////////////////////////////
+
+class WLGDPSTime : public G4VPrimitiveScorer
+{
+public:                                              // with description
+    WLGDPSTime(G4String name, G4int depth = 0);  // default unit
+    WLGDPSTime(G4String name, const G4String& unit, G4int depth = 0);
+    virtual ~WLGDPSTime();
+
+protected:  // with description
+    virtual G4bool ProcessHits(G4Step*, G4TouchableHistory*);
+
+public:
+    virtual void Initialize(G4HCofThisEvent*);
+    virtual void EndOfEvent(G4HCofThisEvent*);
+    virtual void clear();
+    virtual void DrawAll();
+    virtual void PrintAll();
+
+    virtual void SetUnit(const G4String& unit);
+
+private:
+    G4int                      HCID;
+    G4THitsMap<G4double>*      EvtMap;
+};
+#endif

--- a/src/WLGDEventAction.cc
+++ b/src/WLGDEventAction.cc
@@ -5,6 +5,7 @@
 #include "G4HCofThisEvent.hh"
 #include "G4SDManager.hh"
 #include "G4UnitsTable.hh"
+#include "G4ios.hh"
 
 #include "Randomize.hh"
 #include <iomanip>
@@ -154,4 +155,16 @@ void WLGDEventAction::EndOfEventAction(const G4Event* event)
 
     // fill the ntuple
     analysisManager->AddNtupleRow();
+
+    // printing
+    G4int eventID = event->GetEventID();
+    G4cout << ">>> Event: " << eventID << G4endl;
+    G4cout << "    " << edep_water.size() 
+               << " water hits stored in this event." << G4endl;
+    G4cout << "    " << edep_lar.size()
+               << " LAr hits stored in this event." << G4endl;
+    G4cout << "    " << edep_ular.size()
+               << " ULAr hits stored in this event." << G4endl;
+    G4cout << "    " << edep_ge.size()
+               << " germanium hits stored in this event." << G4endl;
 }

--- a/src/WLGDPSLocation.cc
+++ b/src/WLGDPSLocation.cc
@@ -9,7 +9,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 WLGDPSLocation::WLGDPSLocation(G4String name, G4int depth)
-: G4VPrimitiveScorer(name, depth)
+: G4VPrimitiveScorer(std::move(name), depth)
 , HCID(-1)
 , EvtMap(0)
 {
@@ -17,7 +17,7 @@ WLGDPSLocation::WLGDPSLocation(G4String name, G4int depth)
 }
 
 WLGDPSLocation::WLGDPSLocation(G4String name, const G4String& unit, G4int depth)
-: G4VPrimitiveScorer(name, depth)
+: G4VPrimitiveScorer(std::move(name), depth)
 , HCID(-1)
 , EvtMap(0)
 {

--- a/src/WLGDPSLocation.cc
+++ b/src/WLGDPSLocation.cc
@@ -5,14 +5,12 @@
 ////////////////////////////////////////////////////////////////////////////////
 // Description:
 //   This is a primitive scorer class for scoring energy deposit location
-//   at termination of the track.
 //
 ///////////////////////////////////////////////////////////////////////////////
 
 WLGDPSLocation::WLGDPSLocation(G4String name, G4int depth)
 : G4VPrimitiveScorer(name, depth)
 , HCID(-1)
-, fcounter(0)
 , EvtMap(0)
 {
     SetUnit("m");
@@ -21,7 +19,6 @@ WLGDPSLocation::WLGDPSLocation(G4String name, G4int depth)
 WLGDPSLocation::WLGDPSLocation(G4String name, const G4String& unit, G4int depth)
 : G4VPrimitiveScorer(name, depth)
 , HCID(-1)
-, fcounter(0)
 , EvtMap(0)
 {
     SetUnit(unit);
@@ -36,19 +33,19 @@ G4bool WLGDPSLocation::ProcessHits(G4Step* aStep, G4TouchableHistory*)
 
     G4StepPoint*  preStepPoint = aStep->GetPreStepPoint();
     G4ThreeVector loc = preStepPoint->GetPosition();  // location at track creation
+    // keep unit free for storage in ntuple
     loc.setX(loc.x() / GetUnitValue());               // unit value used
     loc.setY(loc.y() / GetUnitValue());
     loc.setZ(loc.z() / GetUnitValue());
 
-    EvtMap->add(fcounter, loc);
+    G4int idx = GetIndex(aStep);
+    EvtMap->add(idx, loc);
 
-    fcounter++;  // next key to process
     return TRUE;
 }
 
 void WLGDPSLocation::Initialize(G4HCofThisEvent* HCE)
 {
-    fcounter = 0;
     EvtMap =
         new G4THitsMap<G4ThreeVector>(GetMultiFunctionalDetector()->GetName(), GetName());
     if(HCID < 0)
@@ -62,7 +59,6 @@ void WLGDPSLocation::EndOfEvent(G4HCofThisEvent*) { ; }
 
 void WLGDPSLocation::clear()
 {
-    fcounter = 0;
     EvtMap->clear();
 }
 

--- a/src/WLGDPSTime.cc
+++ b/src/WLGDPSTime.cc
@@ -28,8 +28,11 @@ WLGDPSTime::~WLGDPSTime() = default;
 
 G4bool WLGDPSTime::ProcessHits(G4Step* aStep, G4TouchableHistory*)
 {
+    // better comment here - what does "all collisions" mean?
     if(aStep->GetPostStepPoint()->GetStepStatus() == fGeomBoundary)
-        return FALSE;  // all collisions
+    {
+        return FALSE;
+    }
 
     // keep unit free for storage in ntuple
     G4double tt = aStep->GetTrack()->GetGlobalTime() / GetUnitValue();

--- a/src/WLGDPSTime.cc
+++ b/src/WLGDPSTime.cc
@@ -1,0 +1,76 @@
+// WLGDPSTime
+#include "WLGDPSTime.hh"
+#include "G4UnitsTable.hh"
+
+////////////////////////////////////////////////////////////////////////////////
+// Description:
+//   This is a primitive scorer class for scoring global track time
+//
+///////////////////////////////////////////////////////////////////////////////
+
+WLGDPSTime::WLGDPSTime(G4String name, G4int depth)
+: G4VPrimitiveScorer(name, depth)
+, HCID(-1)
+, EvtMap(0)
+{
+    SetUnit("ns");
+}
+
+WLGDPSTime::WLGDPSTime(G4String name, const G4String& unit, G4int depth)
+: G4VPrimitiveScorer(name, depth)
+, HCID(-1)
+, EvtMap(0)
+{
+    SetUnit(unit);
+}
+
+WLGDPSTime::~WLGDPSTime() { ; }
+
+G4bool WLGDPSTime::ProcessHits(G4Step* aStep, G4TouchableHistory*)
+{
+    if(aStep->GetPostStepPoint()->GetStepStatus() == fGeomBoundary)
+        return FALSE;  // all collisions
+
+    G4double tt = aStep->GetTrack()->GetGlobalTime();
+
+    G4int idx = GetIndex(aStep);
+    EvtMap->add(idx, tt);
+
+    return TRUE;
+}
+
+void WLGDPSTime::Initialize(G4HCofThisEvent* HCE)
+{
+    EvtMap =
+        new G4THitsMap<G4double>(GetMultiFunctionalDetector()->GetName(), GetName());
+    if(HCID < 0)
+    {
+        HCID = GetCollectionID(0);
+    }
+    HCE->AddHitsCollection(HCID, (G4VHitsCollection*) EvtMap);
+}
+
+void WLGDPSTime::EndOfEvent(G4HCofThisEvent*) { ; }
+
+void WLGDPSTime::clear()
+{
+    EvtMap->clear();
+}
+
+void WLGDPSTime::DrawAll() { ; }
+
+void WLGDPSTime::PrintAll()
+{
+    G4cout << " MultiFunctionalDet  " << detector->GetName() << G4endl;
+    G4cout << " PrimitiveScorer " << GetName() << G4endl;
+    G4cout << " Number of entries " << EvtMap->entries() << G4endl;
+    std::map<G4int, G4double*>::iterator itr = EvtMap->GetMap()->begin();
+    for(; itr != EvtMap->GetMap()->end(); itr++)
+    {
+        G4cout << "  key: " << itr->first << "  global time: "
+               << *(itr->second) / GetUnitValue()
+               << " [" << GetUnit() << "]" << G4endl;
+    }
+}
+
+void WLGDPSTime::SetUnit(const G4String& unit) { CheckAndSetUnit(unit, "Time"); }

--- a/src/WLGDPSTime.cc
+++ b/src/WLGDPSTime.cc
@@ -31,7 +31,8 @@ G4bool WLGDPSTime::ProcessHits(G4Step* aStep, G4TouchableHistory*)
     if(aStep->GetPostStepPoint()->GetStepStatus() == fGeomBoundary)
         return FALSE;  // all collisions
 
-    G4double tt = aStep->GetTrack()->GetGlobalTime();
+    // keep unit free for storage in ntuple
+    G4double tt = aStep->GetTrack()->GetGlobalTime() / GetUnitValue();
 
     G4int idx = GetIndex(aStep);
     EvtMap->add(idx, tt);
@@ -68,7 +69,7 @@ void WLGDPSTime::PrintAll()
     for(; itr != EvtMap->GetMap()->end(); itr++)
     {
         G4cout << "  key: " << itr->first << "  global time: "
-               << *(itr->second) / GetUnitValue()
+               << *(itr->second)
                << " [" << GetUnit() << "]" << G4endl;
     }
 }

--- a/src/WLGDPSTime.cc
+++ b/src/WLGDPSTime.cc
@@ -9,7 +9,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 WLGDPSTime::WLGDPSTime(G4String name, G4int depth)
-: G4VPrimitiveScorer(name, depth)
+: G4VPrimitiveScorer(std::move(name), depth)
 , HCID(-1)
 , EvtMap(0)
 {
@@ -17,14 +17,14 @@ WLGDPSTime::WLGDPSTime(G4String name, G4int depth)
 }
 
 WLGDPSTime::WLGDPSTime(G4String name, const G4String& unit, G4int depth)
-: G4VPrimitiveScorer(name, depth)
+: G4VPrimitiveScorer(std::move(name), depth)
 , HCID(-1)
 , EvtMap(0)
 {
     SetUnit(unit);
 }
 
-WLGDPSTime::~WLGDPSTime() { ; }
+WLGDPSTime::~WLGDPSTime() = default;
 
 G4bool WLGDPSTime::ProcessHits(G4Step* aStep, G4TouchableHistory*)
 {


### PR DESCRIPTION
New primitive scorer to record global hit time at each collision (default [ns]), similar to location scorer. Took out unit in G4double for simple storage in ntuple.
Added event printout of entries in each HC at end of event for checking. 
The time scorer is not used anywhere just yet.