### PR TITLE
Apply clang-tidy fixes

### DIFF
--- a/include/WLGDBiasMultiParticleChangeCrossSection.hh
+++ b/include/WLGDBiasMultiParticleChangeCrossSection.hh
@@ -11,7 +11,7 @@ class WLGDBiasMultiParticleChangeCrossSection : public G4VBiasingOperator
 {
 public:
   WLGDBiasMultiParticleChangeCrossSection();
-  virtual ~WLGDBiasMultiParticleChangeCrossSection() {}
+  virtual ~WLGDBiasMultiParticleChangeCrossSection() = default;
 
   // ---------------------------------
   // -- Method specific to this class:
@@ -19,7 +19,7 @@ public:
   // -- Each particle type for which its name is passed will be biased; *provided*
   // -- that the proper calls to biasingPhysics->Bias(particleName) have been done
   // -- in the main program.
-  void AddParticle(G4String particleName);
+  void AddParticle(const G4String& particleName);
 
 private:
   // -----------------------------

--- a/include/WLGDEventAction.hh
+++ b/include/WLGDEventAction.hh
@@ -15,8 +15,8 @@
 class WLGDEventAction : public G4UserEventAction
 {
 public:
-  WLGDEventAction();
-  virtual ~WLGDEventAction();
+  WLGDEventAction()          = default;
+  virtual ~WLGDEventAction() = default;
 
   virtual void BeginOfEventAction(const G4Event* event);
   virtual void EndOfEventAction(const G4Event* event);
@@ -45,14 +45,14 @@ private:
   G4THitsMap<G4ThreeVector>* GetVecHitsCollection(G4int hcID, const G4Event* event) const;
 
   // data members
-  G4int                 fCollID_water;
-  G4int                 fCollID_lar;
-  G4int                 fCollID_ular;
-  G4int                 fCollID_ge;
-  G4int                 fLocID_water;
-  G4int                 fLocID_lar;
-  G4int                 fLocID_ular;
-  G4int                 fLocID_ge;
+  G4int                 fCollID_water = -1;
+  G4int                 fCollID_lar   = -1;
+  G4int                 fCollID_ular  = -1;
+  G4int                 fCollID_ge    = -1;
+  G4int                 fLocID_water  = -1;
+  G4int                 fLocID_lar    = -1;
+  G4int                 fLocID_ular   = -1;
+  G4int                 fLocID_ge     = -1;
   std::vector<G4double> edep_water;
   std::vector<G4double> edep_lar;
   std::vector<G4double> edep_ular;

--- a/src/WLGDActionInitialization.cc
+++ b/src/WLGDActionInitialization.cc
@@ -7,10 +7,10 @@ WLGDActionInitialization::WLGDActionInitialization(WLGDDetectorConstruction* det
                                                    G4String                  name)
 : G4VUserActionInitialization()
 , fDet(det)
-, foutname(name)
+, foutname(std::move(name))
 {}
 
-WLGDActionInitialization::~WLGDActionInitialization() {}
+WLGDActionInitialization::~WLGDActionInitialization() = default;
 
 void WLGDActionInitialization::BuildForMaster() const
 {

--- a/src/WLGDBiasMultiParticleChangeCrossSection.cc
+++ b/src/WLGDBiasMultiParticleChangeCrossSection.cc
@@ -11,12 +11,12 @@ WLGDBiasMultiParticleChangeCrossSection::WLGDBiasMultiParticleChangeCrossSection
 : G4VBiasingOperator("TestManyExponentialTransform")
 {}
 
-void WLGDBiasMultiParticleChangeCrossSection::AddParticle(G4String particleName)
+void WLGDBiasMultiParticleChangeCrossSection::AddParticle(const G4String& particleName)
 {
   const G4ParticleDefinition* particle =
     G4ParticleTable::GetParticleTable()->FindParticle(particleName);
 
-  if(particle == 0)
+  if(particle == nullptr)
   {
     G4ExceptionDescription ed;
     ed << "Particle `" << particleName << "' not found !" << G4endl;
@@ -34,21 +34,24 @@ G4VBiasingOperation*
 WLGDBiasMultiParticleChangeCrossSection::ProposeOccurenceBiasingOperation(
   const G4Track* track, const G4BiasingProcessInterface* callingProcess)
 {
-  if(fCurrentOperator)
+  if(fCurrentOperator != nullptr)
+  {
     return fCurrentOperator->GetProposedOccurenceBiasingOperation(track, callingProcess);
-  else
-    return 0;
+  }
+
+  return nullptr;
 }
 
 void WLGDBiasMultiParticleChangeCrossSection::StartTracking(const G4Track* track)
 {
   // -- fetch the underneath biasing operator, if any, for the current particle type:
   const G4ParticleDefinition* definition = track->GetParticleDefinition();
-  std::map<const G4ParticleDefinition*, WLGDBiasChangeCrossSection*>::iterator it =
-    fBOptrForParticle.find(definition);
-  fCurrentOperator = 0;
+  auto                        it         = fBOptrForParticle.find(definition);
+  fCurrentOperator                       = nullptr;
   if(it != fBOptrForParticle.end())
+  {
     fCurrentOperator = (*it).second;
+  }
 }
 
 void WLGDBiasMultiParticleChangeCrossSection::OperationApplied(
@@ -58,8 +61,10 @@ void WLGDBiasMultiParticleChangeCrossSection::OperationApplied(
   const G4VParticleChange* particleChangeProduced)
 {
   // -- inform the underneath biasing operator that a biased interaction occured:
-  if(fCurrentOperator)
+  if(fCurrentOperator != nullptr)
+  {
     fCurrentOperator->ReportOperationApplied(
       callingProcess, biasingCase, occurenceOperationApplied,
       weightForOccurenceInteraction, finalStateOperationApplied, particleChangeProduced);
+  }
 }

--- a/src/WLGDDetectorConstruction.cc
+++ b/src/WLGDDetectorConstruction.cc
@@ -37,10 +37,11 @@ WLGDDetectorConstruction::~WLGDDetectorConstruction() { delete fDetectorMessenge
 G4VPhysicalVolume* WLGDDetectorConstruction::Construct()
 {
   if(fBaseline)
+  {
     return SetupBaseline();
+  }
 
-  else
-    return SetupAlternative();
+  return SetupAlternative();
 }
 
 void WLGDDetectorConstruction::ConstructSDandField()
@@ -208,9 +209,9 @@ G4VPhysicalVolume* WLGDDetectorConstruction::SetupAlternative()
   //
   G4VSolid* worldSolid =
     new G4Box("World", worldside * cm, worldside * cm, worldside * cm);
-  auto fWorldLogical = new G4LogicalVolume(worldSolid, worldMaterial, "World_log");
-  auto fWorldPhysical =
-    new G4PVPlacement(0, G4ThreeVector(), fWorldLogical, "World_phys", 0, false, 0);
+  auto fWorldLogical  = new G4LogicalVolume(worldSolid, worldMaterial, "World_log");
+  auto fWorldPhysical = new G4PVPlacement(nullptr, G4ThreeVector(), fWorldLogical,
+                                          "World_phys", nullptr, false, 0);
 
   //
   // Cavern
@@ -219,7 +220,7 @@ G4VPhysicalVolume* WLGDDetectorConstruction::SetupAlternative()
                                     (hallhside + stone) * cm, (hallhside + stone) * cm);
   auto      fCavernLogical = new G4LogicalVolume(cavernSolid, stdRock, "Cavern_log");
   auto      fCavernPhysical =
-    new G4PVPlacement(0, G4ThreeVector(0., 0., offset * cm), fCavernLogical,
+    new G4PVPlacement(nullptr, G4ThreeVector(0., 0., offset * cm), fCavernLogical,
                       "Cavern_phys", fWorldLogical, false, 0);
 
   //
@@ -229,8 +230,8 @@ G4VPhysicalVolume* WLGDDetectorConstruction::SetupAlternative()
     new G4Box("Cavern", hallhside * cm, hallhside * cm, hallhside * cm);
   auto fHallLogical = new G4LogicalVolume(hallSolid, airMat, "Hall_log");
   auto fHallPhysical =
-    new G4PVPlacement(0, G4ThreeVector(0., 0., -stone * cm), fHallLogical, "Hall_phys",
-                      fCavernLogical, false, 0, true);
+    new G4PVPlacement(nullptr, G4ThreeVector(0., 0., -stone * cm), fHallLogical,
+                      "Hall_phys", fCavernLogical, false, 0, true);
 
   //
   // Tank
@@ -238,8 +239,8 @@ G4VPhysicalVolume* WLGDDetectorConstruction::SetupAlternative()
   G4VSolid* tankSolid = new G4Box("Tank", tankhside * cm, tankhside * cm, tankhside * cm);
   auto      fTankLogical = new G4LogicalVolume(tankSolid, steelMat, "Tank_log");
   auto      fTankPhysical =
-    new G4PVPlacement(0, G4ThreeVector(0., 0., -stone * cm), fTankLogical, "Tank_phys",
-                      fHallLogical, false, 0, true);
+    new G4PVPlacement(nullptr, G4ThreeVector(0., 0., -stone * cm), fTankLogical,
+                      "Tank_phys", fHallLogical, false, 0, true);
 
   //
   // Insulator
@@ -248,7 +249,7 @@ G4VPhysicalVolume* WLGDDetectorConstruction::SetupAlternative()
     new G4Box("Insulator", (tankhside - outerwall) * cm, (tankhside - outerwall) * cm,
               (tankhside - outerwall) * cm);
   auto fPuLogical  = new G4LogicalVolume(puSolid, puMat, "Pu_log");
-  auto fPuPhysical = new G4PVPlacement(0, G4ThreeVector(), fPuLogical, "Pu_phys",
+  auto fPuPhysical = new G4PVPlacement(nullptr, G4ThreeVector(), fPuLogical, "Pu_phys",
                                        fTankLogical, false, 0, true);
 
   //
@@ -258,15 +259,15 @@ G4VPhysicalVolume* WLGDDetectorConstruction::SetupAlternative()
     "Membrane", (tankhside - outerwall - insulation) * cm,
     (tankhside - outerwall - insulation) * cm, (tankhside - outerwall - insulation) * cm);
   auto fMembraneLogical  = new G4LogicalVolume(membraneSolid, steelMat, "Membrane_log");
-  auto fMembranePhysical = new G4PVPlacement(0, G4ThreeVector(), fMembraneLogical,
+  auto fMembranePhysical = new G4PVPlacement(nullptr, G4ThreeVector(), fMembraneLogical,
                                              "Membrane_phys", fPuLogical, false, 0, true);
 
   //
   // LAr
   //
-  G4VSolid* larSolid     = new G4Box("LAr", larside * cm, larside * cm, larside * cm);
-  auto      fLarLogical  = new G4LogicalVolume(larSolid, larMat, "Lar_log");
-  auto      fLarPhysical = new G4PVPlacement(0, G4ThreeVector(), fLarLogical, "Lar_phys",
+  G4VSolid* larSolid    = new G4Box("LAr", larside * cm, larside * cm, larside * cm);
+  auto      fLarLogical = new G4LogicalVolume(larSolid, larMat, "Lar_log");
+  auto fLarPhysical = new G4PVPlacement(nullptr, G4ThreeVector(), fLarLogical, "Lar_phys",
                                         fMembraneLogical, false, 0, true);
 
   //
@@ -293,41 +294,41 @@ G4VPhysicalVolume* WLGDDetectorConstruction::SetupAlternative()
   auto fGeLogical     = new G4LogicalVolume(geSolid, roiMat, "Ge_log");
 
   // placements
-  new G4PVPlacement(0, G4ThreeVector(ringrad * cm, 0., cushift * cm), fCopperLogical,
-                    "Copper_phys", fLarLogical, false, 0, true);
+  new G4PVPlacement(nullptr, G4ThreeVector(ringrad * cm, 0., cushift * cm),
+                    fCopperLogical, "Copper_phys", fLarLogical, false, 0, true);
 
-  new G4PVPlacement(0, G4ThreeVector(ringrad * cm, 0., cushift * cm), fUlarLogical,
+  new G4PVPlacement(nullptr, G4ThreeVector(ringrad * cm, 0., cushift * cm), fUlarLogical,
                     "ULar_phys", fLarLogical, false, 0, true);
 
-  new G4PVPlacement(0, G4ThreeVector(0. * cm, 0. * cm, -cushift * cm), fGeLogical,
+  new G4PVPlacement(nullptr, G4ThreeVector(0. * cm, 0. * cm, -cushift * cm), fGeLogical,
                     "Ge_phys", fUlarLogical, false, 0, true);
 
   // tower 2
-  new G4PVPlacement(0, G4ThreeVector(0., ringrad * cm, cushift * cm), fCopperLogical,
-                    "Copper_phys2", fLarLogical, false, 1, true);
+  new G4PVPlacement(nullptr, G4ThreeVector(0., ringrad * cm, cushift * cm),
+                    fCopperLogical, "Copper_phys2", fLarLogical, false, 1, true);
 
-  new G4PVPlacement(0, G4ThreeVector(0., ringrad * cm, cushift * cm), fUlarLogical,
+  new G4PVPlacement(nullptr, G4ThreeVector(0., ringrad * cm, cushift * cm), fUlarLogical,
                     "ULar_phys2", fLarLogical, false, 1, true);
 
   // tower 3
-  new G4PVPlacement(0, G4ThreeVector(-ringrad * cm, 0., cushift * cm), fCopperLogical,
-                    "Copper_phys3", fLarLogical, false, 2, true);
+  new G4PVPlacement(nullptr, G4ThreeVector(-ringrad * cm, 0., cushift * cm),
+                    fCopperLogical, "Copper_phys3", fLarLogical, false, 2, true);
 
-  new G4PVPlacement(0, G4ThreeVector(-ringrad * cm, 0., cushift * cm), fUlarLogical,
+  new G4PVPlacement(nullptr, G4ThreeVector(-ringrad * cm, 0., cushift * cm), fUlarLogical,
                     "ULar_phys3", fLarLogical, false, 2, true);
 
   // tower 4
-  new G4PVPlacement(0, G4ThreeVector(0., -ringrad * cm, cushift * cm), fCopperLogical,
-                    "Copper_phys4", fLarLogical, false, 3, true);
+  new G4PVPlacement(nullptr, G4ThreeVector(0., -ringrad * cm, cushift * cm),
+                    fCopperLogical, "Copper_phys4", fLarLogical, false, 3, true);
 
-  new G4PVPlacement(0, G4ThreeVector(0., -ringrad * cm, cushift * cm), fUlarLogical,
+  new G4PVPlacement(nullptr, G4ThreeVector(0., -ringrad * cm, cushift * cm), fUlarLogical,
                     "ULar_phys4", fLarLogical, false, 3, true);
 
   //
   // User limits
   //
-  G4double      maxTime    = 1 * ms;  // affects long-lived neutrons
-  G4UserLimits* outerlimit = new G4UserLimits(DBL_MAX, DBL_MAX, maxTime);
+  G4double maxTime    = 1 * ms;  // affects long-lived neutrons
+  auto     outerlimit = new G4UserLimits(DBL_MAX, DBL_MAX, maxTime);
   fCavernLogical->SetUserLimits(outerlimit);
   fLarLogical->SetUserLimits(outerlimit);
 
@@ -433,9 +434,9 @@ G4VPhysicalVolume* WLGDDetectorConstruction::SetupBaseline()
   G4VSolid* worldSolid =
     new G4Tubs("World", 0.0 * cm, (hallrad + stone + 0.1) * cm,
                (hallhheight + stone + offset + 0.1) * cm, 0.0, CLHEP::twopi);
-  auto fWorldLogical = new G4LogicalVolume(worldSolid, worldMaterial, "World_log");
-  auto fWorldPhysical =
-    new G4PVPlacement(0, G4ThreeVector(), fWorldLogical, "World_phys", 0, false, 0);
+  auto fWorldLogical  = new G4LogicalVolume(worldSolid, worldMaterial, "World_log");
+  auto fWorldPhysical = new G4PVPlacement(nullptr, G4ThreeVector(), fWorldLogical,
+                                          "World_phys", nullptr, false, 0);
 
   //
   // Cavern
@@ -444,7 +445,7 @@ G4VPhysicalVolume* WLGDDetectorConstruction::SetupBaseline()
                                      (hallhheight + stone) * cm, 0.0, CLHEP::twopi);
   auto      fCavernLogical = new G4LogicalVolume(cavernSolid, stdRock, "Cavern_log");
   auto      fCavernPhysical =
-    new G4PVPlacement(0, G4ThreeVector(0., 0., offset * cm), fCavernLogical,
+    new G4PVPlacement(nullptr, G4ThreeVector(0., 0., offset * cm), fCavernLogical,
                       "Cavern_phys", fWorldLogical, false, 0);
 
   //
@@ -454,8 +455,8 @@ G4VPhysicalVolume* WLGDDetectorConstruction::SetupBaseline()
     new G4Tubs("Hall", 0.0 * cm, hallrad * cm, hallhheight * cm, 0.0, CLHEP::twopi);
   auto fHallLogical = new G4LogicalVolume(hallSolid, airMat, "Hall_log");
   auto fHallPhysical =
-    new G4PVPlacement(0, G4ThreeVector(0., 0., -stone * cm), fHallLogical, "Hall_phys",
-                      fCavernLogical, false, 0, true);
+    new G4PVPlacement(nullptr, G4ThreeVector(0., 0., -stone * cm), fHallLogical,
+                      "Hall_phys", fCavernLogical, false, 0, true);
 
   //
   // Tank
@@ -465,17 +466,17 @@ G4VPhysicalVolume* WLGDDetectorConstruction::SetupBaseline()
                (tankrad + tankwalltop) * cm, tankhheight * cm, 0.0, CLHEP::twopi);
   auto fTankLogical = new G4LogicalVolume(tankSolid, steelMat, "Tank_log");
   auto fTankPhysical =
-    new G4PVPlacement(0, G4ThreeVector(0., 0., -stone * cm), fTankLogical, "Tank_phys",
-                      fHallLogical, false, 0, true);
+    new G4PVPlacement(nullptr, G4ThreeVector(0., 0., -stone * cm), fTankLogical,
+                      "Tank_phys", fHallLogical, false, 0, true);
 
   //
   // Water
   //
-  G4VSolid* waterSolid    = new G4Tubs("Water", 0.0 * cm, tankrad * cm,
+  G4VSolid* waterSolid     = new G4Tubs("Water", 0.0 * cm, tankrad * cm,
                                     (tankhheight - tankwallbot) * cm, 0.0, CLHEP::twopi);
-  auto      fWaterLogical = new G4LogicalVolume(waterSolid, waterMat, "Water_log");
-  auto fWaterPhysical = new G4PVPlacement(0, G4ThreeVector(), fWaterLogical, "Water_phys",
-                                          fTankLogical, false, 0, true);
+  auto      fWaterLogical  = new G4LogicalVolume(waterSolid, waterMat, "Water_log");
+  auto      fWaterPhysical = new G4PVPlacement(nullptr, G4ThreeVector(), fWaterLogical,
+                                          "Water_phys", fTankLogical, false, 0, true);
 
   //
   // outer cryostat
@@ -483,17 +484,17 @@ G4VPhysicalVolume* WLGDDetectorConstruction::SetupBaseline()
   G4VSolid* coutSolid =
     new G4Tubs("Cout", 0.0 * cm, cryrad * cm, cryhheight * cm, 0.0, CLHEP::twopi);
   auto fCoutLogical  = new G4LogicalVolume(coutSolid, steelMat, "Cout_log");
-  auto fCoutPhysical = new G4PVPlacement(0, G4ThreeVector(), fCoutLogical, "Cout_phys",
-                                         fWaterLogical, false, 0, true);
+  auto fCoutPhysical = new G4PVPlacement(nullptr, G4ThreeVector(), fCoutLogical,
+                                         "Cout_phys", fWaterLogical, false, 0, true);
 
   //
   // vacuum gap
   //
-  G4VSolid* cvacSolid    = new G4Tubs("Cvac", 0.0 * cm, (cryrad - cryowall) * cm,
+  G4VSolid* cvacSolid     = new G4Tubs("Cvac", 0.0 * cm, (cryrad - cryowall) * cm,
                                    cryhheight * cm, 0.0, CLHEP::twopi);
-  auto      fCvacLogical = new G4LogicalVolume(cvacSolid, worldMaterial, "Cvac_log");
-  auto fCvacPhysical = new G4PVPlacement(0, G4ThreeVector(), fCvacLogical, "Cvac_phys",
-                                         fCoutLogical, false, 0, true);
+  auto      fCvacLogical  = new G4LogicalVolume(cvacSolid, worldMaterial, "Cvac_log");
+  auto      fCvacPhysical = new G4PVPlacement(nullptr, G4ThreeVector(), fCvacLogical,
+                                         "Cvac_phys", fCoutLogical, false, 0, true);
 
   //
   // inner cryostat
@@ -501,16 +502,16 @@ G4VPhysicalVolume* WLGDDetectorConstruction::SetupBaseline()
   G4VSolid* cinnSolid    = new G4Tubs("Cinn", 0.0 * cm, (cryrad - cryowall - vacgap) * cm,
                                    cryhheight * cm, 0.0, CLHEP::twopi);
   auto      fCinnLogical = new G4LogicalVolume(cinnSolid, steelMat, "Cinn_log");
-  auto fCinnPhysical = new G4PVPlacement(0, G4ThreeVector(), fCinnLogical, "Cinn_phys",
-                                         fCvacLogical, false, 0, true);
+  auto      fCinnPhysical = new G4PVPlacement(nullptr, G4ThreeVector(), fCinnLogical,
+                                         "Cinn_phys", fCvacLogical, false, 0, true);
 
   //
   // LAr bath
   //
   G4VSolid* larSolid = new G4Tubs("LAr", 0.0 * cm, (cryrad - 2 * cryowall - vacgap) * cm,
                                   cryhheight * cm, 0.0, CLHEP::twopi);
-  auto      fLarLogical  = new G4LogicalVolume(larSolid, larMat, "Lar_log");
-  auto      fLarPhysical = new G4PVPlacement(0, G4ThreeVector(), fLarLogical, "Lar_phys",
+  auto      fLarLogical = new G4LogicalVolume(larSolid, larMat, "Lar_log");
+  auto fLarPhysical = new G4PVPlacement(nullptr, G4ThreeVector(), fLarLogical, "Lar_phys",
                                         fCinnLogical, false, 0, true);
 
   //
@@ -520,11 +521,11 @@ G4VPhysicalVolume* WLGDDetectorConstruction::SetupBaseline()
     new G4Tubs("Lid", 0.0 * cm, cryrad * cm, cryowall / 2.0 * cm, 0.0, CLHEP::twopi);
   auto fLidLogical = new G4LogicalVolume(lidSolid, steelMat, "Lid_log");
   auto fLidPhysical =
-    new G4PVPlacement(0, G4ThreeVector(0., 0., (cryhheight + cryowall / 2.0) * cm),
+    new G4PVPlacement(nullptr, G4ThreeVector(0., 0., (cryhheight + cryowall / 2.0) * cm),
                       fLidLogical, "Lid_phys", fWaterLogical, false, 0, true);
   auto fBotLogical = new G4LogicalVolume(lidSolid, steelMat, "Bot_log");
   auto fBotPhysical =
-    new G4PVPlacement(0, G4ThreeVector(0., 0., -(cryhheight + cryowall / 2.0) * cm),
+    new G4PVPlacement(nullptr, G4ThreeVector(0., 0., -(cryhheight + cryowall / 2.0) * cm),
                       fBotLogical, "Bot_phys", fWaterLogical, false, 0, true);
 
   //
@@ -551,41 +552,41 @@ G4VPhysicalVolume* WLGDDetectorConstruction::SetupBaseline()
   auto fGeLogical     = new G4LogicalVolume(geSolid, roiMat, "Ge_log");
 
   // placements
-  new G4PVPlacement(0, G4ThreeVector(ringrad * cm, 0., cushift * cm), fCopperLogical,
-                    "Copper_phys", fLarLogical, false, 0, true);
+  new G4PVPlacement(nullptr, G4ThreeVector(ringrad * cm, 0., cushift * cm),
+                    fCopperLogical, "Copper_phys", fLarLogical, false, 0, true);
 
-  new G4PVPlacement(0, G4ThreeVector(ringrad * cm, 0., cushift * cm), fUlarLogical,
+  new G4PVPlacement(nullptr, G4ThreeVector(ringrad * cm, 0., cushift * cm), fUlarLogical,
                     "ULar_phys", fLarLogical, false, 0, true);
 
-  new G4PVPlacement(0, G4ThreeVector(0. * cm, 0. * cm, -cushift * cm), fGeLogical,
+  new G4PVPlacement(nullptr, G4ThreeVector(0. * cm, 0. * cm, -cushift * cm), fGeLogical,
                     "Ge_phys", fUlarLogical, false, 0, true);
 
   // tower 2
-  new G4PVPlacement(0, G4ThreeVector(0., ringrad * cm, cushift * cm), fCopperLogical,
-                    "Copper_phys2", fLarLogical, false, 1, true);
+  new G4PVPlacement(nullptr, G4ThreeVector(0., ringrad * cm, cushift * cm),
+                    fCopperLogical, "Copper_phys2", fLarLogical, false, 1, true);
 
-  new G4PVPlacement(0, G4ThreeVector(0., ringrad * cm, cushift * cm), fUlarLogical,
+  new G4PVPlacement(nullptr, G4ThreeVector(0., ringrad * cm, cushift * cm), fUlarLogical,
                     "ULar_phys2", fLarLogical, false, 1, true);
 
   // tower 3
-  new G4PVPlacement(0, G4ThreeVector(-ringrad * cm, 0., cushift * cm), fCopperLogical,
-                    "Copper_phys3", fLarLogical, false, 2, true);
+  new G4PVPlacement(nullptr, G4ThreeVector(-ringrad * cm, 0., cushift * cm),
+                    fCopperLogical, "Copper_phys3", fLarLogical, false, 2, true);
 
-  new G4PVPlacement(0, G4ThreeVector(-ringrad * cm, 0., cushift * cm), fUlarLogical,
+  new G4PVPlacement(nullptr, G4ThreeVector(-ringrad * cm, 0., cushift * cm), fUlarLogical,
                     "ULar_phys3", fLarLogical, false, 2, true);
 
   // tower 4
-  new G4PVPlacement(0, G4ThreeVector(0., -ringrad * cm, cushift * cm), fCopperLogical,
-                    "Copper_phys4", fLarLogical, false, 3, true);
+  new G4PVPlacement(nullptr, G4ThreeVector(0., -ringrad * cm, cushift * cm),
+                    fCopperLogical, "Copper_phys4", fLarLogical, false, 3, true);
 
-  new G4PVPlacement(0, G4ThreeVector(0., -ringrad * cm, cushift * cm), fUlarLogical,
+  new G4PVPlacement(nullptr, G4ThreeVector(0., -ringrad * cm, cushift * cm), fUlarLogical,
                     "ULar_phys4", fLarLogical, false, 3, true);
 
   //
   // User limits
   //
-  G4double      maxTime    = 1 * ms;  // affects long-lived neutrons
-  G4UserLimits* outerlimit = new G4UserLimits(DBL_MAX, DBL_MAX, maxTime);
+  G4double maxTime    = 1 * ms;  // affects long-lived neutrons
+  auto     outerlimit = new G4UserLimits(DBL_MAX, DBL_MAX, maxTime);
   fCavernLogical->SetUserLimits(outerlimit);
   fWaterLogical->SetUserLimits(outerlimit);
   fLarLogical->SetUserLimits(outerlimit);

--- a/src/WLGDEventAction.cc
+++ b/src/WLGDEventAction.cc
@@ -11,27 +11,13 @@
 #include <iomanip>
 #include <vector>
 
-WLGDEventAction::WLGDEventAction()
-: G4UserEventAction()
-, fCollID_water(-1)
-, fCollID_lar(-1)
-, fCollID_ular(-1)
-, fCollID_ge(-1)
-, fLocID_water(-1)
-, fLocID_lar(-1)
-, fLocID_ular(-1)
-, fLocID_ge(-1)
-{}
-
-WLGDEventAction::~WLGDEventAction() {}
-
 G4THitsMap<G4double>* WLGDEventAction::GetHitsCollection(G4int          hcID,
                                                          const G4Event* event) const
 {
   auto hitsCollection =
     static_cast<G4THitsMap<G4double>*>(event->GetHCofThisEvent()->GetHC(hcID));
 
-  if(!hitsCollection)
+  if(hitsCollection == nullptr)
   {
     G4ExceptionDescription msg;
     msg << "Cannot access hitsCollection ID " << hcID;
@@ -48,7 +34,7 @@ G4THitsMap<G4ThreeVector>* WLGDEventAction::GetVecHitsCollection(
   auto hitsCollection =
     static_cast<G4THitsMap<G4ThreeVector>*>(event->GetHCofThisEvent()->GetHC(hcID));
 
-  if(!hitsCollection)
+  if(hitsCollection == nullptr)
   {
     G4ExceptionDescription msg;
     msg << "Cannot access hitsCollection ID " << hcID;
@@ -63,107 +49,111 @@ void WLGDEventAction::BeginOfEventAction(const G4Event* /*event*/) {}
 
 void WLGDEventAction::EndOfEventAction(const G4Event* event)
 {
-    // Get hist collections IDs
-    if(fCollID_lar < 0)
-    {
-      fCollID_water = G4SDManager::GetSDMpointer()->GetCollectionID("WaterDet/Edep");
-      fCollID_lar   = G4SDManager::GetSDMpointer()->GetCollectionID("LarDet/Edep");
-      fCollID_ular  = G4SDManager::GetSDMpointer()->GetCollectionID("ULarDet/Edep");
-      fCollID_ge    = G4SDManager::GetSDMpointer()->GetCollectionID("GeDet/Edep");
+  // Get hist collections IDs
+  if(fCollID_lar < 0)
+  {
+    fCollID_water = G4SDManager::GetSDMpointer()->GetCollectionID("WaterDet/Edep");
+    fCollID_lar   = G4SDManager::GetSDMpointer()->GetCollectionID("LarDet/Edep");
+    fCollID_ular  = G4SDManager::GetSDMpointer()->GetCollectionID("ULarDet/Edep");
+    fCollID_ge    = G4SDManager::GetSDMpointer()->GetCollectionID("GeDet/Edep");
 
-      fLocID_water = G4SDManager::GetSDMpointer()->GetCollectionID("WaterDet/Loc");
-      fLocID_lar   = G4SDManager::GetSDMpointer()->GetCollectionID("LarDet/Loc");
-      fLocID_ular  = G4SDManager::GetSDMpointer()->GetCollectionID("ULarDet/Loc");
-      fLocID_ge    = G4SDManager::GetSDMpointer()->GetCollectionID("GeDet/Loc");
-    }
+    fLocID_water = G4SDManager::GetSDMpointer()->GetCollectionID("WaterDet/Loc");
+    fLocID_lar   = G4SDManager::GetSDMpointer()->GetCollectionID("LarDet/Loc");
+    fLocID_ular  = G4SDManager::GetSDMpointer()->GetCollectionID("ULarDet/Loc");
+    fLocID_ge    = G4SDManager::GetSDMpointer()->GetCollectionID("GeDet/Loc");
+  }
 
-    // Get entries from hits collections
-    //
-    G4THitsMap<G4double>*      waterHitsMap = GetHitsCollection(fCollID_water, event);
-    G4THitsMap<G4double>*      larHitsMap   = GetHitsCollection(fCollID_lar, event);
-    G4THitsMap<G4double>*      ularHitsMap  = GetHitsCollection(fCollID_ular, event);
-    G4THitsMap<G4double>*      geHitsMap    = GetHitsCollection(fCollID_ge, event);
-    G4THitsMap<G4ThreeVector>* waterLocMap  = GetVecHitsCollection(fLocID_water, event);
-    G4THitsMap<G4ThreeVector>* larLocMap    = GetVecHitsCollection(fLocID_lar, event);
-    G4THitsMap<G4ThreeVector>* ularLocMap   = GetVecHitsCollection(fLocID_ular, event);
-    G4THitsMap<G4ThreeVector>* geLocMap     = GetVecHitsCollection(fLocID_ge, event);
+  // Get entries from hits collections
+  //
+  G4THitsMap<G4double>*      waterHitsMap = GetHitsCollection(fCollID_water, event);
+  G4THitsMap<G4double>*      larHitsMap   = GetHitsCollection(fCollID_lar, event);
+  G4THitsMap<G4double>*      ularHitsMap  = GetHitsCollection(fCollID_ular, event);
+  G4THitsMap<G4double>*      geHitsMap    = GetHitsCollection(fCollID_ge, event);
+  G4THitsMap<G4ThreeVector>* waterLocMap  = GetVecHitsCollection(fLocID_water, event);
+  G4THitsMap<G4ThreeVector>* larLocMap    = GetVecHitsCollection(fLocID_lar, event);
+  G4THitsMap<G4ThreeVector>* ularLocMap   = GetVecHitsCollection(fLocID_ular, event);
+  G4THitsMap<G4ThreeVector>* geLocMap     = GetVecHitsCollection(fLocID_ge, event);
 
-    // get analysis manager
-    auto analysisManager = G4AnalysisManager::Instance();
+  // get analysis manager
+  auto analysisManager = G4AnalysisManager::Instance();
 
-    // 8 columns to fill
-    if(!edep_lar.empty())
-    {  // clear vectors
-      edep_water.clear();
-      edep_lar.clear();
-      edep_ular.clear();
-      edep_ge.clear();
-      xLoc_water.clear();
-      xLoc_lar.clear();
-      xLoc_ular.clear();
-      xLoc_ge.clear();
-      yLoc_water.clear();
-      yLoc_lar.clear();
-      yLoc_ular.clear();
-      yLoc_ge.clear();
-      zLoc_water.clear();
-      zLoc_lar.clear();
-      zLoc_ular.clear();
-      zLoc_ge.clear();
-    }
+  // 8 columns to fill
+  if(!edep_lar.empty())
+  {  // clear vectors
+    edep_water.clear();
+    edep_lar.clear();
+    edep_ular.clear();
+    edep_ge.clear();
+    xLoc_water.clear();
+    xLoc_lar.clear();
+    xLoc_ular.clear();
+    xLoc_ge.clear();
+    yLoc_water.clear();
+    yLoc_lar.clear();
+    yLoc_ular.clear();
+    yLoc_ge.clear();
+    zLoc_water.clear();
+    zLoc_lar.clear();
+    zLoc_ular.clear();
+    zLoc_ge.clear();
+  }
 
-    for(auto it : *waterHitsMap->GetMap())
-      edep_water.push_back(*it.second);
+  for(auto it : *waterHitsMap->GetMap())
+  {
+    edep_water.push_back(*it.second);
+  }
 
-    for(auto it : *larHitsMap->GetMap())
-      edep_lar.push_back(*it.second);
+  for(auto it : *larHitsMap->GetMap())
+  {
+    edep_lar.push_back(*it.second);
+  }
 
-    for(auto it : *ularHitsMap->GetMap())
-      edep_ular.push_back(*it.second);
+  for(auto it : *ularHitsMap->GetMap())
+  {
+    edep_ular.push_back(*it.second);
+  }
 
-    for(auto it : *geHitsMap->GetMap())
-      edep_ge.push_back(*it.second);
+  for(auto it : *geHitsMap->GetMap())
+  {
+    edep_ge.push_back(*it.second);
+  }
 
-    for(auto it : *waterLocMap->GetMap())
-    {
-      xLoc_water.push_back((*it.second).x());
-      yLoc_water.push_back((*it.second).y());
-      zLoc_water.push_back((*it.second).z());
-    }
+  for(auto it : *waterLocMap->GetMap())
+  {
+    xLoc_water.push_back((*it.second).x());
+    yLoc_water.push_back((*it.second).y());
+    zLoc_water.push_back((*it.second).z());
+  }
 
-    for(auto it : *larLocMap->GetMap())
-    {
-      xLoc_lar.push_back((*it.second).x());
-      yLoc_lar.push_back((*it.second).y());
-      zLoc_lar.push_back((*it.second).z());
-    }
+  for(auto it : *larLocMap->GetMap())
+  {
+    xLoc_lar.push_back((*it.second).x());
+    yLoc_lar.push_back((*it.second).y());
+    zLoc_lar.push_back((*it.second).z());
+  }
 
-    for(auto it : *ularLocMap->GetMap())
-    {
-      xLoc_ular.push_back((*it.second).x());
-      yLoc_ular.push_back((*it.second).y());
-      zLoc_ular.push_back((*it.second).z());
-    }
+  for(auto it : *ularLocMap->GetMap())
+  {
+    xLoc_ular.push_back((*it.second).x());
+    yLoc_ular.push_back((*it.second).y());
+    zLoc_ular.push_back((*it.second).z());
+  }
 
-    for(auto it : *geLocMap->GetMap())
-    {
-      xLoc_ge.push_back((*it.second).x());
-      yLoc_ge.push_back((*it.second).y());
-      zLoc_ge.push_back((*it.second).z());
-    }
+  for(auto it : *geLocMap->GetMap())
+  {
+    xLoc_ge.push_back((*it.second).x());
+    yLoc_ge.push_back((*it.second).y());
+    zLoc_ge.push_back((*it.second).z());
+  }
 
-    // fill the ntuple
-    analysisManager->AddNtupleRow();
+  // fill the ntuple
+  analysisManager->AddNtupleRow();
 
-    // printing
-    G4int eventID = event->GetEventID();
-    G4cout << ">>> Event: " << eventID << G4endl;
-    G4cout << "    " << edep_water.size() 
-               << " water hits stored in this event." << G4endl;
-    G4cout << "    " << edep_lar.size()
-               << " LAr hits stored in this event." << G4endl;
-    G4cout << "    " << edep_ular.size()
-               << " ULAr hits stored in this event." << G4endl;
-    G4cout << "    " << edep_ge.size()
-               << " germanium hits stored in this event." << G4endl;
+  // printing
+  G4int eventID = event->GetEventID();
+  G4cout << ">>> Event: " << eventID << G4endl;
+  G4cout << "    " << edep_water.size() << " water hits stored in this event." << G4endl;
+  G4cout << "    " << edep_lar.size() << " LAr hits stored in this event." << G4endl;
+  G4cout << "    " << edep_ular.size() << " ULAr hits stored in this event." << G4endl;
+  G4cout << "    " << edep_ge.size() << " germanium hits stored in this event." << G4endl;
 }

--- a/src/WLGDPSLocation.cc
+++ b/src/WLGDPSLocation.cc
@@ -11,7 +11,7 @@
 WLGDPSLocation::WLGDPSLocation(G4String name, G4int depth)
 : G4VPrimitiveScorer(std::move(name), depth)
 , HCID(-1)
-, EvtMap(0)
+, EvtMap(nullptr)
 {
   SetUnit("m");
 }
@@ -19,22 +19,24 @@ WLGDPSLocation::WLGDPSLocation(G4String name, G4int depth)
 WLGDPSLocation::WLGDPSLocation(G4String name, const G4String& unit, G4int depth)
 : G4VPrimitiveScorer(std::move(name), depth)
 , HCID(-1)
-, EvtMap(0)
+, EvtMap(nullptr)
 {
   SetUnit(unit);
 }
 
 WLGDPSLocation::~WLGDPSLocation() { ; }
 
-G4bool WLGDPSLocation::ProcessHits(G4Step* aStep, G4TouchableHistory*)
+G4bool WLGDPSLocation::ProcessHits(G4Step* aStep, G4TouchableHistory* /*unused*/)
 {
   if(aStep->GetPostStepPoint()->GetStepStatus() == fGeomBoundary)
+  {
     return FALSE;  // collisions
+  }
 
   G4StepPoint*  preStepPoint = aStep->GetPreStepPoint();
   G4ThreeVector loc          = preStepPoint->GetPosition();  // location at track creation
   // keep unit free for storage in ntuple
-  loc.setX(loc.x() / GetUnitValue());                        // unit value used
+  loc.setX(loc.x() / GetUnitValue());  // unit value used
   loc.setY(loc.y() / GetUnitValue());
   loc.setZ(loc.z() / GetUnitValue());
 
@@ -55,12 +57,9 @@ void WLGDPSLocation::Initialize(G4HCofThisEvent* HCE)
   HCE->AddHitsCollection(HCID, (G4VHitsCollection*) EvtMap);
 }
 
-void WLGDPSLocation::EndOfEvent(G4HCofThisEvent*) { ; }
+void WLGDPSLocation::EndOfEvent(G4HCofThisEvent* /*unused*/) { ; }
 
-void WLGDPSLocation::clear()
-{
-  EvtMap->clear();
-}
+void WLGDPSLocation::clear() { EvtMap->clear(); }
 
 void WLGDPSLocation::DrawAll() { ; }
 
@@ -69,7 +68,7 @@ void WLGDPSLocation::PrintAll()
   G4cout << " MultiFunctionalDet  " << detector->GetName() << G4endl;
   G4cout << " PrimitiveScorer " << GetName() << G4endl;
   G4cout << " Number of entries " << EvtMap->entries() << G4endl;
-  std::map<G4int, G4ThreeVector*>::iterator itr = EvtMap->GetMap()->begin();
+  auto itr = EvtMap->GetMap()->begin();
   for(; itr != EvtMap->GetMap()->end(); itr++)
   {
     G4cout << "  key: " << itr->first << "  energy deposit at: (" << (*(itr->second)).x()

--- a/src/WLGDPSTime.cc
+++ b/src/WLGDPSTime.cc
@@ -11,70 +11,65 @@
 WLGDPSTime::WLGDPSTime(G4String name, G4int depth)
 : G4VPrimitiveScorer(std::move(name), depth)
 , HCID(-1)
-, EvtMap(0)
+, EvtMap(nullptr)
 {
-    SetUnit("ns");
+  SetUnit("ns");
 }
 
 WLGDPSTime::WLGDPSTime(G4String name, const G4String& unit, G4int depth)
 : G4VPrimitiveScorer(std::move(name), depth)
 , HCID(-1)
-, EvtMap(0)
+, EvtMap(nullptr)
 {
-    SetUnit(unit);
+  SetUnit(unit);
 }
 
 WLGDPSTime::~WLGDPSTime() = default;
 
-G4bool WLGDPSTime::ProcessHits(G4Step* aStep, G4TouchableHistory*)
+G4bool WLGDPSTime::ProcessHits(G4Step* aStep, G4TouchableHistory* /*unused*/)
 {
-    // better comment here - what does "all collisions" mean?
-    if(aStep->GetPostStepPoint()->GetStepStatus() == fGeomBoundary)
-    {
-        return FALSE;
-    }
+  // better comment here - what does "all collisions" mean?
+  if(aStep->GetPostStepPoint()->GetStepStatus() == fGeomBoundary)
+  {
+    return false;
+  }
 
-    // keep unit free for storage in ntuple
-    G4double tt = aStep->GetTrack()->GetGlobalTime() / GetUnitValue();
+  // keep unit free for storage in ntuple
+  G4double tt = aStep->GetTrack()->GetGlobalTime() / GetUnitValue();
 
-    G4int idx = GetIndex(aStep);
-    EvtMap->add(idx, tt);
+  G4int idx = GetIndex(aStep);
+  EvtMap->add(idx, tt);
 
-    return TRUE;
+  return true;
 }
 
 void WLGDPSTime::Initialize(G4HCofThisEvent* HCE)
 {
-    EvtMap =
-        new G4THitsMap<G4double>(GetMultiFunctionalDetector()->GetName(), GetName());
-    if(HCID < 0)
-    {
-        HCID = GetCollectionID(0);
-    }
-    HCE->AddHitsCollection(HCID, (G4VHitsCollection*) EvtMap);
+  EvtMap = new G4THitsMap<G4double>(GetMultiFunctionalDetector()->GetName(), GetName());
+  if(HCID < 0)
+  {
+    HCID = GetCollectionID(0);
+  }
+  HCE->AddHitsCollection(HCID, (G4VHitsCollection*) EvtMap);
 }
 
-void WLGDPSTime::EndOfEvent(G4HCofThisEvent*) { ; }
+void WLGDPSTime::EndOfEvent(G4HCofThisEvent* /*unused*/) { ; }
 
-void WLGDPSTime::clear()
-{
-    EvtMap->clear();
-}
+void WLGDPSTime::clear() { EvtMap->clear(); }
 
 void WLGDPSTime::DrawAll() { ; }
 
 void WLGDPSTime::PrintAll()
 {
-    G4cout << " MultiFunctionalDet  " << detector->GetName() << G4endl;
-    G4cout << " PrimitiveScorer " << GetName() << G4endl;
-    G4cout << " Number of entries " << EvtMap->entries() << G4endl;
-    std::map<G4int, G4double*>::iterator itr = EvtMap->GetMap()->begin();
-    for(; itr != EvtMap->GetMap()->end(); itr++)
-    {
-        G4cout << "  key: " << itr->first << "  global time: "
-               << *(itr->second)
-               << " [" << GetUnit() << "]" << G4endl;
-    }
+  G4cout << " MultiFunctionalDet  " << detector->GetName() << G4endl;
+  G4cout << " PrimitiveScorer " << GetName() << G4endl;
+  G4cout << " Number of entries " << EvtMap->entries() << G4endl;
+  auto itr = EvtMap->GetMap()->begin();
+  for(; itr != EvtMap->GetMap()->end(); itr++)
+  {
+    G4cout << "  key: " << itr->first << "  global time: " << *(itr->second) << " ["
+           << GetUnit() << "]" << G4endl;
+  }
 }
 
 void WLGDPSTime::SetUnit(const G4String& unit) { CheckAndSetUnit(unit, "Time"); }

--- a/src/WLGDPrimaryGeneratorAction.cc
+++ b/src/WLGDPrimaryGeneratorAction.cc
@@ -41,7 +41,7 @@ WLGDPrimaryGeneratorAction::~WLGDPrimaryGeneratorAction()
 
 void WLGDPrimaryGeneratorAction::GeneratePrimaries(G4Event* event)
 {
-  typedef std::piecewise_linear_distribution<double> pld_type;
+  using pld_type = std::piecewise_linear_distribution<double>;
 
   int    nw             = 100;     // number of bins
   double lower_bound    = 1.0;     // energy interval lower bound [GeV]
@@ -54,20 +54,17 @@ void WLGDPrimaryGeneratorAction::GeneratePrimaries(G4Event* event)
   pld_type cosd(nw, nearhorizontal, fullcosangle, MuAngle(fDepth));
 
   // momentum vector
-  double px, py, pz;
-  double sintheta, sinphi, costheta, cosphi;
+  G4double costheta = cosd(generator);  // get a random number
+  G4double sintheta = std::sqrt(1. - costheta * costheta);
 
-  costheta = cosd(generator);  // get a random number
-  sintheta = std::sqrt(1. - costheta * costheta);
+  std::uniform_real_distribution<> rndm(0.0, 1.0);   // azimuth angle
+  G4double phi    = CLHEP::twopi * rndm(generator);  // random uniform number
+  G4double sinphi = std::sin(phi);
+  G4double cosphi = std::cos(phi);
 
-  std::uniform_real_distribution<> rndm(0.0, 1.0);  // azimuth angle
-  double phi = CLHEP::twopi * rndm(generator);      // random uniform number
-  sinphi     = std::sin(phi);
-  cosphi     = std::cos(phi);
-
-  px = -sintheta * cosphi;
-  py = -sintheta * sinphi;
-  pz = -costheta;  // default downwards: pz = -1.0
+  G4double      px = -sintheta * cosphi;
+  G4double      py = -sintheta * sinphi;
+  G4double      pz = -costheta;  // default downwards: pz = -1.0
   G4ThreeVector momentumDir(px, py, pz);
   fParticleGun->SetParticleMomentumDirection(momentumDir);
 

--- a/src/WLGDRunAction.cc
+++ b/src/WLGDRunAction.cc
@@ -10,7 +10,7 @@
 WLGDRunAction::WLGDRunAction(WLGDEventAction* eventAction, G4String name)
 : G4UserRunAction()
 , fEventAction(eventAction)
-, fout(name)
+, fout(std::move(name))
 {
   // Create analysis manager
   auto analysisManager = G4AnalysisManager::Instance();

--- a/warwick-legend.cc
+++ b/warwick-legend.cc
@@ -54,14 +54,14 @@ int main(int argc, char** argv)
     std::min(nthreads, G4Threading::G4GetNumberOfCores());  // limit thread number to
                                                             // max on machine
 
-  G4MTRunManager* runManager = new G4MTRunManager;
+  auto runManager = new G4MTRunManager;
   G4cout << "      ********* Run Manager constructed in MT mode: " << nthreads
          << " threads ***** " << G4endl;
   runManager->SetNumberOfThreads(nthreads);
 
 #else
 
-  G4RunManager* runManager = new G4RunManager;
+  auto runManager = new G4RunManager;
   G4cout << "      ********** Run Manager constructed in sequential mode ************ "
          << G4endl;
 


### PR DESCRIPTION
Apply all suggested changes from clang-tidy apart from magic numbers and unneeded base class init. There are many magic numbers, particularly in geometry, but these are best addressed through a dedicated refactoring task. Redundant base class init needs understanding against standard, and is only considered a readability fix, so not important at present time.