### PR TITLE
Allow warwick-legend to run in G4 interactive mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,12 +1,18 @@
 cmake_minimum_required(VERSION 3.12)
 project(warwick-legend VERSION 0.1.0)
 
+# Compiler/build settings
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
+# CTest if we need it
+include(CTest)
+
+# Dependencies
 find_package(Geant4 10.6 REQUIRED ui_all vis_all)
 
+# Build
 add_executable(warwick-legend
   warwick-legend.cc
   src/WLGDActionInitialization.cc
@@ -27,3 +33,15 @@ add_executable(warwick-legend
   src/WLGDTrajectory.cc)
 target_include_directories(warwick-legend PRIVATE ${PROJECT_SOURCE_DIR}/include)
 target_link_libraries(warwick-legend PRIVATE ${Geant4_LIBRARIES})
+
+# Copy macro needed to run in interactive mode to build directory.
+# By default, the macro is assumed to be in the working directory
+# where warwick-legend is run from.
+configure_file(vis.mac vis.mac COPYONLY)
+
+
+# Test
+if(BUILD_TESTING)
+  # 1. Check that we can run the most trivial example
+  add_test(NAME minimal-run COMMAND warwick-legend -m "${PROJECT_SOURCE_DIR}/test0.mac")
+endif()

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # warwick-legend
 Legend muon background simulations
 
-First attempt at creating a LEGEND Monte-Carlo simulation application, 
-suitable for large production runs estimating Germanium-77 production in 
+First attempt at creating a LEGEND Monte-Carlo simulation application,
+suitable for large production runs estimating Germanium-77 production in
 Germanium-76 crystals in different underground laboratories.
 
 Should allow for two alternative experimental setups.
@@ -13,14 +13,14 @@ Multi-threading operation and MPI capability
 
 ROOT ntuple output
 
-Biasing of neutron production by muons (physics bias), 
-neutron population inside cryostant (geometry bias) and 
+Biasing of neutron production by muons (physics bias),
+neutron population inside cryostant (geometry bias) and
 neutron capture reaction (Ge-77 production from n,gamma reaction)
 
 Operate with command line input and Geant4 macro.
 
-Macro commands for change of geometry, one material in the geometry, 
-primary vertex generator, cross section bias factor (one each, neutron and muon), 
+Macro commands for change of geometry, one material in the geometry,
+primary vertex generator, cross section bias factor (one each, neutron and muon),
 bias split factor (integer >= 2)
 
 CLI for number of threads, macro file, output file name (for production runs)
@@ -34,6 +34,7 @@ The project has the following requirements:
 - C++17 compatible compiler (GCC9, Xcode 11 tested at present)
 - CMake 3.12 or newer
 - Geant4 10.6 built with multithreading and gdml support
+  - Qt or OpenGL/X11 driver support if you want to visualize the geometry/tracks/hits
 
 It may be compiled using:
 
@@ -43,9 +44,28 @@ $ cmake ..
 $ make
 ```
 
-Support files for `[clang-format](https://clang.llvm.org/docs/ClangFormat.html)` and `[clang-tidy](https://clang.llvm.org/extra/clang-tidy/)` are provided to help automate formatting (following the 
-Geant4 style) and static analysis respectively. No explicit setup is needed 
-for autoformatting other than the relevant integration settings of your 
+Testing is enabled by default via the `BUILD_TESTING` CMake argument and may be run after
+building by running
+
+```
+$ ctest
+```
+
+Run `ctest --help` for options to select tests and/or run with increased verbosity, e.g.
+
+```
+$ ctest -VV
+```
+
+to get verbose (including stdout) output from the setup and execution of the tests.
+
+The resulting `warwick-legend` application may be run without arguments to start an interactive
+session. Otherwise run `warwick-legend --help` to see a list of options for batch mode running.
+
+
+Support files for `[clang-format](https://clang.llvm.org/docs/ClangFormat.html)` and `[clang-tidy](https://clang.llvm.org/extra/clang-tidy/)` are provided to help automate formatting (following the
+Geant4 style) and static analysis respectively. No explicit setup is needed
+for autoformatting other than the relevant integration settings of your
 favoured editor/IDE ([vim](http://clang.llvm.org/docs/ClangFormat.html#vim-integration), [emacs](http://clang.llvm.org/docs/ClangFormat.html#emacs-integration), [vscode](https://code.visualstudio.com/docs/cpp/cpp-ide#_code-formatting)). To enable static
 analysis, ensure you have `clang-tidy` installed and run the build as:
 
@@ -55,14 +75,14 @@ $ cmake -DCMAKE_CXX_CLANG_TIDY="/path/to/clang-tidy" ..
 $ make
 ```
 
-The `.clang-tidy` file supplied in this project will be used, and suggestions 
+The `.clang-tidy` file supplied in this project will be used, and suggestions
 for fixes will be emitted whilst building. At present, the `-fix` option is
-automatically apply the suggested change is not used to leave the decision 
+automatically apply the suggested change is not used to leave the decision
 up to the developer. The set of fixes applied are:
 
 - `readability-*`
 - `modernize-*`
-- `performance-*` 
+- `performance-*`
 
 For a full listing of the wildcards, see [the `clang-tidy` documentation](https://clang.llvm.org/extra/clang-tidy/checks/list.html).
 


### PR DESCRIPTION
Update main program following Geant4 examples to create and use an interactive session when no macro file is supplied. This will launch the "best" UI/Vis driver available from the used Geant4 install. In most cases this will be Qt or tcsh+OpenGL/X11.

Provide a simple test to run warwick-legend in batch mode to assure this is not affected.

This is a pre-step for checking/fixing the geometry model selection as visualisation helps to confirm this is working. As built on SCRTP with LCG97 this will build, _but_ the visualisation appears not to work over X2go, a seemingly known limitation of trying to run GLX over that. Confirmed to work on local macOS however, and the above test should confirm that batch mode runs correctly.