### PR TITLE
Pregeom

### DIFF
--- a/src/WLGDDetectorConstruction.cc
+++ b/src/WLGDDetectorConstruction.cc
@@ -144,32 +144,32 @@ void WLGDDetectorConstruction::ConstructSDandField()
 
     // ----------------------------------------------
     // -- operator creation and attachment to volume:
-    // ----------------------------------------------    
+    // ----------------------------------------------
     G4LogicalVolumeStore* volumeStore = G4LogicalVolumeStore::GetInstance();
-    
+
     // -- Attach neutron XS biasing to Germanium -> enhance nCapture
     auto* biasnXS = new WLGDBiasMultiParticleChangeCrossSection();
     biasnXS->AddParticle("neutron");
     G4LogicalVolume* logicGe = volumeStore->GetVolume("Ge_log");
     biasnXS->AttachTo(logicGe);
-   
+
     // -- Attach muon XS biasing to all required volumes consistently
     auto* biasmuXS = new WLGDBiasMultiParticleChangeCrossSection();
     biasmuXS->AddParticle("mu-");
-   
+
     G4LogicalVolume* logicCavern = volumeStore->GetVolume("Cavern_log");
     biasmuXS->AttachTo(logicCavern);
     G4LogicalVolume* logicHall = volumeStore->GetVolume("Hall_log");
     biasmuXS->AttachTo(logicHall);
     G4LogicalVolume* logicTank = volumeStore->GetVolume("Tank_log");
     biasmuXS->AttachTo(logicTank);
-    G4LogicalVolume* logicLar = volumeStore->GetVolume("Lar_log");  
+    G4LogicalVolume* logicLar = volumeStore->GetVolume("Lar_log");
     biasmuXS->AttachTo(logicLar);
     G4LogicalVolume* logicCu = volumeStore->GetVolume("Copper_log");
     biasmuXS->AttachTo(logicCu);
     G4LogicalVolume* logicULar = volumeStore->GetVolume("ULar_log");
     biasmuXS->AttachTo(logicULar);
-  
+
     // Baseline also has a water volume and cryostat
     if(fGeometryName == "baseline")
     {
@@ -192,13 +192,11 @@ void WLGDDetectorConstruction::ConstructSDandField()
       G4LogicalVolume* logicMembrane = volumeStore->GetVolume("Membrane_log");
       biasmuXS->AttachTo(logicMembrane);
     }
-
   }
   else
   {
     G4cout << " >>> fSD has entry. Repeated call." << G4endl;
   }
-
 }
 
 auto WLGDDetectorConstruction::SetupAlternative() -> G4VPhysicalVolume*

--- a/src/WLGDDetectorConstruction.cc
+++ b/src/WLGDDetectorConstruction.cc
@@ -139,60 +139,66 @@ void WLGDDetectorConstruction::ConstructSDandField()
 
     // Also only add it once to the SD manager!
     G4SDManager::GetSDMpointer()->AddNewDetector(fSD.Get());
+
+    SetSensitiveDetector("Ge_log", fSD.Get());
+
+    // ----------------------------------------------
+    // -- operator creation and attachment to volume:
+    // ----------------------------------------------    
+    G4LogicalVolumeStore* volumeStore = G4LogicalVolumeStore::GetInstance();
+    
+    // -- Attach neutron XS biasing to Germanium -> enhance nCapture
+    auto* biasnXS = new WLGDBiasMultiParticleChangeCrossSection();
+    biasnXS->AddParticle("neutron");
+    G4LogicalVolume* logicGe = volumeStore->GetVolume("Ge_log");
+    biasnXS->AttachTo(logicGe);
+   
+    // -- Attach muon XS biasing to all required volumes consistently
+    auto* biasmuXS = new WLGDBiasMultiParticleChangeCrossSection();
+    biasmuXS->AddParticle("mu-");
+   
+    G4LogicalVolume* logicCavern = volumeStore->GetVolume("Cavern_log");
+    biasmuXS->AttachTo(logicCavern);
+    G4LogicalVolume* logicHall = volumeStore->GetVolume("Hall_log");
+    biasmuXS->AttachTo(logicHall);
+    G4LogicalVolume* logicTank = volumeStore->GetVolume("Tank_log");
+    biasmuXS->AttachTo(logicTank);
+    G4LogicalVolume* logicLar = volumeStore->GetVolume("Lar_log");  
+    biasmuXS->AttachTo(logicLar);
+    G4LogicalVolume* logicCu = volumeStore->GetVolume("Copper_log");
+    biasmuXS->AttachTo(logicCu);
+    G4LogicalVolume* logicULar = volumeStore->GetVolume("ULar_log");
+    biasmuXS->AttachTo(logicULar);
+  
+    // Baseline also has a water volume and cryostat
+    if(fGeometryName == "baseline")
+    {
+      G4LogicalVolume* logicWater = volumeStore->GetVolume("Water_log");
+      biasmuXS->AttachTo(logicWater);
+      G4LogicalVolume* logicCout = volumeStore->GetVolume("Cout_log");
+      biasmuXS->AttachTo(logicCout);
+      G4LogicalVolume* logicCinn = volumeStore->GetVolume("Cinn_log");
+      biasmuXS->AttachTo(logicCinn);
+      G4LogicalVolume* logicCLid = volumeStore->GetVolume("Lid_log");
+      biasmuXS->AttachTo(logicCLid);
+      G4LogicalVolume* logicCBot = volumeStore->GetVolume("Bot_log");
+      biasmuXS->AttachTo(logicCBot);
+    }
+    // Alternative has the membrane and insulator
+    else if(fGeometryName == "alternative")
+    {
+      G4LogicalVolume* logicPu = volumeStore->GetVolume("Pu_log");
+      biasmuXS->AttachTo(logicPu);
+      G4LogicalVolume* logicMembrane = volumeStore->GetVolume("Membrane_log");
+      biasmuXS->AttachTo(logicMembrane);
+    }
+
   }
-
-  SetSensitiveDetector("Ge_log", fSD.Get());
-
-  // ----------------------------------------------
-  // -- operator creation and attachment to volume:
-  // ----------------------------------------------
-  G4LogicalVolumeStore* volumeStore = G4LogicalVolumeStore::GetInstance();
-
-  // -- Attach neutron XS biasing to Germanium -> enhance nCapture
-  auto* biasnXS = new WLGDBiasMultiParticleChangeCrossSection();
-  biasnXS->AddParticle("neutron");
-  G4LogicalVolume* logicGe = volumeStore->GetVolume("Ge_log");
-  biasnXS->AttachTo(logicGe);
-
-  // -- Attach muon XS biasing to all required volumes consistently
-  auto* biasmuXS = new WLGDBiasMultiParticleChangeCrossSection();
-  biasmuXS->AddParticle("mu-");
-
-  G4LogicalVolume* logicCavern = volumeStore->GetVolume("Cavern_log");
-  biasmuXS->AttachTo(logicCavern);
-  G4LogicalVolume* logicHall = volumeStore->GetVolume("Hall_log");
-  biasmuXS->AttachTo(logicHall);
-  G4LogicalVolume* logicTank = volumeStore->GetVolume("Tank_log");
-  biasmuXS->AttachTo(logicTank);
-  G4LogicalVolume* logicLar = volumeStore->GetVolume("Lar_log");
-  biasmuXS->AttachTo(logicLar);
-  G4LogicalVolume* logicCu = volumeStore->GetVolume("Copper_log");
-  biasmuXS->AttachTo(logicCu);
-  G4LogicalVolume* logicULar = volumeStore->GetVolume("ULar_log");
-  biasmuXS->AttachTo(logicULar);
-
-  // Baseline also has a water volume and cryostat
-  if(fGeometryName == "baseline")
+  else
   {
-    G4LogicalVolume* logicWater = volumeStore->GetVolume("Water_log");
-    biasmuXS->AttachTo(logicWater);
-    G4LogicalVolume* logicCout = volumeStore->GetVolume("Cout_log");
-    biasmuXS->AttachTo(logicCout);
-    G4LogicalVolume* logicCinn = volumeStore->GetVolume("Cinn_log");
-    biasmuXS->AttachTo(logicCinn);
-    G4LogicalVolume* logicCLid = volumeStore->GetVolume("Lid_log");
-    biasmuXS->AttachTo(logicCLid);
-    G4LogicalVolume* logicCBot = volumeStore->GetVolume("Bot_log");
-    biasmuXS->AttachTo(logicCBot);
+    G4cout << " >>> fSD has entry. Repeated call." << G4endl;
   }
-  // Alternative has the membrane and insulator
-  else if(fGeometryName == "alternative")
-  {
-    G4LogicalVolume* logicPu = volumeStore->GetVolume("Pu_log");
-    biasmuXS->AttachTo(logicPu);
-    G4LogicalVolume* logicMembrane = volumeStore->GetVolume("Membrane_log");
-    biasmuXS->AttachTo(logicMembrane);
-  }
+
 }
 
 auto WLGDDetectorConstruction::SetupAlternative() -> G4VPhysicalVolume*

--- a/src/WLGDDetectorConstruction.cc
+++ b/src/WLGDDetectorConstruction.cc
@@ -643,6 +643,6 @@ void WLGDDetectorConstruction::DefineCommands()
     .SetGuidance("baseline = NEEDS DESCRIPTION")
     .SetGuidance("alternative = NEEDS DESCRIPTION")
     .SetCandidates("baseline alternative")
-    .SetStates(G4State_PreInit, G4State_Idle)
+    .SetStates(G4State_PreInit)
     .SetToBeBroadcasted(false);
 }

--- a/src/WLGDEventAction.cc
+++ b/src/WLGDEventAction.cc
@@ -144,7 +144,7 @@ void WLGDEventAction::EndOfEventAction(const G4Event* event)
     G4String        pname = trj->GetParticleName();  // filter on particle name
     G4int           Z     = trj->GetParticleDefinition()->GetAtomicNumber();
     G4int           A     = trj->GetParticleDefinition()->GetAtomicMass();
-    if(pname == "neutron" || (Z == 32 && A == 77))
+    if(pname == "neutron" || pname == "mu-" || (Z == 32 && A == 77))
     {
       trjtid.push_back(trj->GetTrackID());
       trjpid.push_back(trj->GetParentID());

--- a/src/WLGDEventAction.cc
+++ b/src/WLGDEventAction.cc
@@ -79,9 +79,9 @@ void WLGDEventAction::BeginOfEventAction(const G4Event*
   trjpid.clear();
   trjpdg.clear();
   trjnpts.clear();
-  trjxvtz.clear();
-  trjyvtz.clear();
-  trjzvtz.clear();
+  trjxvtx.clear();
+  trjyvtx.clear();
+  trjzvtx.clear();
   trjxpos.clear();
   trjypos.clear();
   trjzpos.clear();

--- a/src/WLGDEventAction.cc
+++ b/src/WLGDEventAction.cc
@@ -74,6 +74,17 @@ void WLGDEventAction::BeginOfEventAction(const G4Event*
   xloc.clear();
   yloc.clear();
   zloc.clear();
+  // clear trajectory data
+  trjtid.clear();
+  trjpid.clear();
+  trjpdg.clear();
+  trjnpts.clear();
+  trjxvtz.clear();
+  trjyvtz.clear();
+  trjzvtz.clear();
+  trjxpos.clear();
+  trjypos.clear();
+  trjzpos.clear();
 }
 
 void WLGDEventAction::EndOfEventAction(const G4Event* event)

--- a/test/test-swap-geometry.mac
+++ b/test/test-swap-geometry.mac
@@ -1,11 +1,21 @@
-# minimal commands to change geometry between runs
-# baseline
-/run/beamOn 1
+# minimal command set test
+# verbose
+/run/verbose 1
+/event/verbose 0
+/tracking/verbose 0
+
+# set default cut
+/run/setCut 3.0 cm
 
 # alternative
 /WLGD/detector/setGeometry alternative
-/run/beamOn 1
 
-# restore baseline
-/WLGD/detector/setGeometry baseline
-/run/beamOn 1
+# run init
+/run/initialize
+
+# lab depth [km.w.e.]
+/WLGD/generator/depth 5.89
+
+# start
+/run/beamOn 4
+

--- a/test/test0.mac
+++ b/test/test0.mac
@@ -6,6 +6,9 @@
 # set default cut
 /run/setCut 3.0 cm
 
+# run init
+/run/initialize
+
 # lab depth [km.w.e.]
 /WLGD/generator/depth 5.89
 

--- a/warwick-legend.cc
+++ b/warwick-legend.cc
@@ -104,12 +104,12 @@ int main(int argc, char** argv)
 
   // Initialize G4 kernel
   //
-  runManager->Initialize();
+  // runManager->Initialize();
 
   // Visualization manager
   //
-  auto visManager = std::make_unique<G4VisExecutive>();
-  visManager->Initialize();
+  // auto visManager = std::make_unique<G4VisExecutive>();
+  // visManager->Initialize();
 
   // Get the pointer to the User Interface manager
   //
@@ -117,6 +117,9 @@ int main(int argc, char** argv)
 
   if(ui != nullptr)  // Define UI session for interactive mode
   {
+    auto visManager = std::make_unique<G4VisExecutive>();
+    visManager->Initialize();
+
     UImanager->ApplyCommand("/control/execute vis.mac");
     ui->SessionStart();
     // UI must be deleted *before* the vis manager


### PR DESCRIPTION
This PR appears to remove the initialization problems when choosing a different geometry compared to the default baseline. The run initialization is removed from main() and set into the macro as an essential ingredient such that the geometry choice command in the macro can act first. The protection of bias operator set ups and sensitive detector instantiation removes all warnings and Geant error messages.