### PR TITLE
Change bias

### DIFF
--- a/include/WLGDBiasChangeCrossSection.hh
+++ b/include/WLGDBiasChangeCrossSection.hh
@@ -17,8 +17,8 @@ public:
 
   // -- method called at beginning of run:
   virtual void StartRun();
-  void SetNeutronFactor(const G4double& nf) { fNeutronBias = nf; }
-  void SetMuonFactor(const G4double& mf) { fMuonBias = mf; }
+  void         SetNeutronFactor(const G4double& nf) { fNeutronBias = nf; }
+  void         SetMuonFactor(const G4double& mf) { fMuonBias = mf; }
 
 private:
   // -----------------------------
@@ -66,7 +66,6 @@ private:
   G4String                    fpname;
   G4double                    fNeutronBias = 1.0;
   G4double                    fMuonBias    = 1.0;
-
 };
 
 #endif

--- a/include/WLGDBiasChangeCrossSection.hh
+++ b/include/WLGDBiasChangeCrossSection.hh
@@ -17,6 +17,8 @@ public:
 
   // -- method called at beginning of run:
   virtual void StartRun();
+  void SetNeutronFactor(const G4double& nf) { fNeutronBias = nf; }
+  void SetMuonFactor(const G4double& mf) { fMuonBias = mf; }
 
 private:
   // -----------------------------
@@ -62,6 +64,9 @@ private:
   G4bool                      fSetup;
   const G4ParticleDefinition* fParticleToBias;
   G4String                    fpname;
+  G4double                    fNeutronBias = 1.0;
+  G4double                    fMuonBias    = 1.0;
+
 };
 
 #endif

--- a/include/WLGDBiasMultiParticleChangeCrossSection.hh
+++ b/include/WLGDBiasMultiParticleChangeCrossSection.hh
@@ -20,6 +20,9 @@ public:
   // -- that the proper calls to biasingPhysics->Bias(particleName) have been done
   // -- in the main program.
   void AddParticle(const G4String& particleName);
+  void SetNeutronFactor(const G4double& nf) { fNeutronBias = nf; }
+  void SetMuonFactor(const G4double& mf) { fMuonBias = mf; }
+
 
 private:
   // -----------------------------
@@ -68,6 +71,8 @@ private:
   std::map<const G4ParticleDefinition*, WLGDBiasChangeCrossSection*> fBOptrForParticle;
   std::vector<const G4ParticleDefinition*>                           fParticlesToBias;
   WLGDBiasChangeCrossSection*                                        fCurrentOperator;
+  G4double fNeutronBias = 1.0;
+  G4double fMuonBias    = 1.0;
 };
 
 #endif

--- a/include/WLGDBiasMultiParticleChangeCrossSection.hh
+++ b/include/WLGDBiasMultiParticleChangeCrossSection.hh
@@ -23,7 +23,6 @@ public:
   void SetNeutronFactor(const G4double& nf) { fNeutronBias = nf; }
   void SetMuonFactor(const G4double& mf) { fMuonBias = mf; }
 
-
 private:
   // -----------------------------
   // -- Mandatory from base class:
@@ -71,8 +70,8 @@ private:
   std::map<const G4ParticleDefinition*, WLGDBiasChangeCrossSection*> fBOptrForParticle;
   std::vector<const G4ParticleDefinition*>                           fParticlesToBias;
   WLGDBiasChangeCrossSection*                                        fCurrentOperator;
-  G4double fNeutronBias = 1.0;
-  G4double fMuonBias    = 1.0;
+  G4double                                                           fNeutronBias = 1.0;
+  G4double                                                           fMuonBias    = 1.0;
 };
 
 #endif

--- a/include/WLGDDetectorConstruction.hh
+++ b/include/WLGDDetectorConstruction.hh
@@ -22,6 +22,8 @@ public:
   G4double GetWorldSizeZ() { return fvertexZ; }  // inline
   G4double GetWorldExtent() { return fmaxrad; }  // --"--
   void     SetGeometry(const G4String& name);
+  void     SetNeutronBiasFactor(const G4double& nf);
+  void     SetMuonBiasFactor(const G4double& mf);
 
 private:
   void DefineCommands();
@@ -31,9 +33,12 @@ private:
   G4VPhysicalVolume* SetupAlternative();
 
   G4GenericMessenger*                 fDetectorMessenger = nullptr;
+  G4GenericMessenger*                 fBiasMessenger     = nullptr;
   G4double                            fvertexZ           = -1.0;
   G4double                            fmaxrad            = -1.0;
   G4String                            fGeometryName      = "baseline";
+  G4double                            fNeutronBias       = 1.0;
+  G4double                            fMuonBias          = 1.0;
   G4Cache<G4MultiFunctionalDetector*> fSD                = nullptr;
 };
 

--- a/src/WLGDBiasChangeCrossSection.cc
+++ b/src/WLGDBiasChangeCrossSection.cc
@@ -97,12 +97,12 @@ G4VBiasingOperation* WLGDBiasChangeCrossSection::ProposeOccurenceBiasingOperatio
   G4double XStransformation;
   if(fpname.contains("mu-"))
   {
-    XStransformation = 1000.0;  // hard-code cross section boost factor
+    XStransformation = fMuonBias;  // configurable cross section boost factor
   }
   else if(fpname.contains("neutron"))
   {
     XStransformation =
-      10.0 * 1.68;  // specific for this, boost n,gamma by 68% for 77Ge from 76Ge
+      fNeutronBias * 1.68;  // specific for this, boost n,gamma by 68% for 77Ge from 76Ge
   }
   else
   {

--- a/src/WLGDBiasChangeCrossSection.cc
+++ b/src/WLGDBiasChangeCrossSection.cc
@@ -95,7 +95,7 @@ G4VBiasingOperation* WLGDBiasChangeCrossSection::ProposeOccurenceBiasingOperatio
   // -- direction dependent, like in the exponential transform MCNP case, or it
   // -- can be chosen differently, depending on the process, etc.
   G4double XStransformation;
-  // G4cout << " >>> ChangeCrossSection: got muon bias " << fMuonBias 
+  // G4cout << " >>> ChangeCrossSection: got muon bias " << fMuonBias
   //        << ", n factor " << fNeutronBias << G4endl;
   if(fpname.contains("mu-"))
   {

--- a/src/WLGDBiasChangeCrossSection.cc
+++ b/src/WLGDBiasChangeCrossSection.cc
@@ -95,6 +95,8 @@ G4VBiasingOperation* WLGDBiasChangeCrossSection::ProposeOccurenceBiasingOperatio
   // -- direction dependent, like in the exponential transform MCNP case, or it
   // -- can be chosen differently, depending on the process, etc.
   G4double XStransformation;
+  // G4cout << " >>> ChangeCrossSection: got muon bias " << fMuonBias 
+  //        << ", n factor " << fNeutronBias << G4endl;
   if(fpname.contains("mu-"))
   {
     XStransformation = fMuonBias;  // configurable cross section boost factor

--- a/src/WLGDBiasMultiParticleChangeCrossSection.cc
+++ b/src/WLGDBiasMultiParticleChangeCrossSection.cc
@@ -26,6 +26,8 @@ void WLGDBiasMultiParticleChangeCrossSection::AddParticle(const G4String& partic
   }
 
   WLGDBiasChangeCrossSection* optr = new WLGDBiasChangeCrossSection(particleName);
+  optr->SetNeutronFactor(fNeutronBias);
+  optr->SetMuonFactor(fMuonBias);
   fParticlesToBias.push_back(particle);
   fBOptrForParticle[particle] = optr;
 }

--- a/src/WLGDBiasMultiParticleChangeCrossSection.cc
+++ b/src/WLGDBiasMultiParticleChangeCrossSection.cc
@@ -28,6 +28,7 @@ void WLGDBiasMultiParticleChangeCrossSection::AddParticle(const G4String& partic
   WLGDBiasChangeCrossSection* optr = new WLGDBiasChangeCrossSection(particleName);
   optr->SetNeutronFactor(fNeutronBias);
   optr->SetMuonFactor(fMuonBias);
+  G4cout << " >>> MultiBias: set neutron and muon factors to " << fNeutronBias << ", " << fMuonBias << G4endl;
   fParticlesToBias.push_back(particle);
   fBOptrForParticle[particle] = optr;
 }

--- a/src/WLGDBiasMultiParticleChangeCrossSection.cc
+++ b/src/WLGDBiasMultiParticleChangeCrossSection.cc
@@ -28,7 +28,8 @@ void WLGDBiasMultiParticleChangeCrossSection::AddParticle(const G4String& partic
   WLGDBiasChangeCrossSection* optr = new WLGDBiasChangeCrossSection(particleName);
   optr->SetNeutronFactor(fNeutronBias);
   optr->SetMuonFactor(fMuonBias);
-  G4cout << " >>> MultiBias: set neutron and muon factors to " << fNeutronBias << ", " << fMuonBias << G4endl;
+  G4cout << " >>> MultiBias: set neutron and muon factors to " << fNeutronBias << ", "
+         << fMuonBias << G4endl;
   fParticlesToBias.push_back(particle);
   fBOptrForParticle[particle] = optr;
 }

--- a/src/WLGDDetectorConstruction.cc
+++ b/src/WLGDDetectorConstruction.cc
@@ -41,9 +41,9 @@ WLGDDetectorConstruction::WLGDDetectorConstruction()
   DefineMaterials();
 }
 
-WLGDDetectorConstruction::~WLGDDetectorConstruction() 
-{ 
-  delete fDetectorMessenger; 
+WLGDDetectorConstruction::~WLGDDetectorConstruction()
+{
+  delete fDetectorMessenger;
   delete fBiasMessenger;
 }
 
@@ -646,10 +646,7 @@ void WLGDDetectorConstruction::SetNeutronBiasFactor(const G4double& nf)
   fNeutronBias = nf;
 }
 
-void WLGDDetectorConstruction::SetMuonBiasFactor(const G4double& mf)
-{
-  fMuonBias = mf;
-}
+void WLGDDetectorConstruction::SetMuonBiasFactor(const G4double& mf) { fMuonBias = mf; }
 
 void WLGDDetectorConstruction::DefineCommands()
 {
@@ -667,16 +664,18 @@ void WLGDDetectorConstruction::DefineCommands()
     .SetToBeBroadcasted(false);
 
   // Define bias operator command directory using generic messenger class
-  fBiasMessenger = new G4GenericMessenger(this, "/WLGD/bias/",
-                                          "Commands for controlling bias factors");
+  fBiasMessenger =
+    new G4GenericMessenger(this, "/WLGD/bias/", "Commands for controlling bias factors");
 
   // switch commands
-  fBiasMessenger->DeclareMethod("setNeutronBias", &WLGDDetectorConstruction::SetNeutronBiasFactor)
+  fBiasMessenger
+    ->DeclareMethod("setNeutronBias", &WLGDDetectorConstruction::SetNeutronBiasFactor)
     .SetGuidance("Set Bias factor for neutron capture process.")
     .SetDefaultValue("1.0")
     .SetStates(G4State_PreInit)
     .SetToBeBroadcasted(false);
-  fBiasMessenger->DeclareMethod("setMuonBias", &WLGDDetectorConstruction::SetMuonBiasFactor)
+  fBiasMessenger
+    ->DeclareMethod("setMuonBias", &WLGDDetectorConstruction::SetMuonBiasFactor)
     .SetGuidance("Set Bias factor for muon nuclear process.")
     .SetDefaultValue("1.0")
     .SetStates(G4State_PreInit)

--- a/src/WLGDDetectorConstruction.cc
+++ b/src/WLGDDetectorConstruction.cc
@@ -154,13 +154,17 @@ void WLGDDetectorConstruction::ConstructSDandField()
     // -- Attach neutron XS biasing to Germanium -> enhance nCapture
     auto* biasnXS = new WLGDBiasMultiParticleChangeCrossSection();
     biasnXS->SetNeutronFactor(fNeutronBias);
+    biasnXS->SetMuonFactor(fMuonBias);
+    G4cout << " >>> Detector: set neutron bias to " << fNeutronBias << G4endl;
     biasnXS->AddParticle("neutron");
     G4LogicalVolume* logicGe = volumeStore->GetVolume("Ge_log");
     biasnXS->AttachTo(logicGe);
 
     // -- Attach muon XS biasing to all required volumes consistently
     auto* biasmuXS = new WLGDBiasMultiParticleChangeCrossSection();
+    biasmuXS->SetNeutronFactor(fNeutronBias);
     biasmuXS->SetMuonFactor(fMuonBias);
+    G4cout << " >>> Detector: set muon bias to " << fMuonBias << G4endl;
     biasmuXS->AddParticle("mu-");
 
     G4LogicalVolume* logicCavern = volumeStore->GetVolume("Cavern_log");
@@ -667,17 +671,13 @@ void WLGDDetectorConstruction::DefineCommands()
                                           "Commands for controlling bias factors");
 
   // switch commands
-  fDetectorMessenger->DeclareMethod("setNeutronBias", &WLGDDetectorConstruction::SetNeutronBiasFactor)
+  fBiasMessenger->DeclareMethod("setNeutronBias", &WLGDDetectorConstruction::SetNeutronBiasFactor)
     .SetGuidance("Set Bias factor for neutron capture process.")
-    .SetParameterName("nf", true)
-    .SetRange("nf>=1.0")
     .SetDefaultValue("1.0")
     .SetStates(G4State_PreInit)
     .SetToBeBroadcasted(false);
-  fDetectorMessenger->DeclareMethod("setMuonBias", &WLGDDetectorConstruction::SetMuonBiasFactor)
+  fBiasMessenger->DeclareMethod("setMuonBias", &WLGDDetectorConstruction::SetMuonBiasFactor)
     .SetGuidance("Set Bias factor for muon nuclear process.")
-    .SetParameterName("mf", true)    
-    .SetRange("mf>=1.0")
     .SetDefaultValue("1.0")
     .SetStates(G4State_PreInit)
     .SetToBeBroadcasted(false);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3,3 +3,7 @@ add_test(NAME minimal-run COMMAND warwick-legend -m "${CMAKE_CURRENT_LIST_DIR}/t
 
 # 2. Check geometry can be switched
 add_test(NAME swap-geometry COMMAND warwick-legend -m "${CMAKE_CURRENT_LIST_DIR}/test-swap-geometry.mac")
+
+# 3. Check bias can be switched
+add_test(NAME change-bias COMMAND warwick-legend -m "${CMAKE_CURRENT_LIST_DIR}/test-chenge-bias.mac")
+

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -5,5 +5,5 @@ add_test(NAME minimal-run COMMAND warwick-legend -m "${CMAKE_CURRENT_LIST_DIR}/t
 add_test(NAME swap-geometry COMMAND warwick-legend -m "${CMAKE_CURRENT_LIST_DIR}/test-swap-geometry.mac")
 
 # 3. Check bias can be switched
-add_test(NAME change-bias COMMAND warwick-legend -m "${CMAKE_CURRENT_LIST_DIR}/test-chenge-bias.mac")
+add_test(NAME change-bias COMMAND warwick-legend -m "${CMAKE_CURRENT_LIST_DIR}/test-change-bias.mac")
 

--- a/test/test-change-bias.mac
+++ b/test/test-change-bias.mac
@@ -1,0 +1,22 @@
+# minimal command set test
+# verbose
+/run/verbose 1
+/event/verbose 0
+/tracking/verbose 0
+
+# set default cut
+/run/setCut 3.0 cm
+
+# bias commands
+/WLGD/bias/setNeutronBias 10.0
+/WLGD/bias/setMuonBias 20.0
+
+# run init
+/run/initialize
+
+# lab depth [km.w.e.]
+/WLGD/generator/depth 5.89
+
+# start
+/run/beamOn 4
+


### PR DESCRIPTION
This PR addresses the feature on configuring the bias factors for changing cross sections for (a) neutron capture on Ge and (b) muon nuclear reaction for neutron production from muons. Hard-coded bias factors were unsatisfactory. This way, brute force simulations can be set with bias factors set to 1.0 and variance reduction with increased cross section bias factors set in macro. The systematic neutron capture XS enhancement of 68% from the Gerda paper is hard-coded in the factor (i.e. factor times 1.68).

# bias commands
/WLGD/bias/setNeutronBias 10.0
/WLGD/bias/setMuonBias 20.0
