### PR TITLE
Do not store trajectories by default

### DIFF
--- a/src/WLGDEventAction.cc
+++ b/src/WLGDEventAction.cc
@@ -106,7 +106,7 @@ void WLGDEventAction::EndOfEventAction(const G4Event* event)
   G4THitsMap<G4double>*      HitsMap  = GetHitsCollection(fEdepID, event);
   G4THitsMap<G4ThreeVector>* LocMap   = GetVecHitsCollection(fLocID, event);
   G4THitsMap<G4double>*      TimeMap  = GetHitsCollection(fTimeID, event);
- 
+
   if (THitsMap->entries()<=0)
   {
     return;   // no action on no event in Germanium
@@ -139,9 +139,9 @@ void WLGDEventAction::EndOfEventAction(const G4Event* event)
     hpaid.push_back((*it.second));
   }
 
-  // fill trajectory data
+  // fill trajectory data if available
   G4TrajectoryContainer* trajectoryContainer = event->GetTrajectoryContainer();
-  G4int                  n_trajectories      = trajectoryContainer->entries();
+  G4int n_trajectories = (trajectoryContainer == nullptr) ? 0 : trajectoryContainer->entries();
 
   for(G4int i = 0; i < n_trajectories; i++)
   {
@@ -172,5 +172,5 @@ void WLGDEventAction::EndOfEventAction(const G4Event* event)
 
   // extract the trajectories and print them out
   G4cout << G4endl;
-  G4cout << "Trajectories in tracker: " << n_trajectories << G4endl;
+  G4cout << "Trajectories stored: " << n_trajectories << G4endl;
 }

--- a/src/WLGDTrackingAction.cc
+++ b/src/WLGDTrackingAction.cc
@@ -9,10 +9,11 @@ WLGDTrackingAction::WLGDTrackingAction() = default;
 
 void WLGDTrackingAction::PreUserTrackingAction(const G4Track* aTrack)
 {
-  // Create trajectory for track
-
-  fpTrackingManager->SetStoreTrajectory(true);
-  fpTrackingManager->SetTrajectory(new WLGDTrajectory(aTrack));
+  // Create trajectory for track if requested
+  if(fpTrackingManager->GetStoreTrajectory() > 0)
+  {
+    fpTrackingManager->SetTrajectory(new WLGDTrajectory(aTrack));
+  }
 }
 
 void WLGDTrackingAction::PostUserTrackingAction(const G4Track* aTrack)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -7,3 +7,6 @@ add_test(NAME swap-geometry COMMAND warwick-legend -m "${CMAKE_CURRENT_LIST_DIR}
 # 3. Check bias can be switched
 add_test(NAME change-bias COMMAND warwick-legend -m "${CMAKE_CURRENT_LIST_DIR}/test-change-bias.mac")
 
+# 4. Check trajectory storage runs
+add_test(NAME trajectory-storage COMMAND warwick-legend -m "${CMAKE_CURRENT_LIST_DIR}/test-trajectory-storage.mac")
+

--- a/test/test-store-trajectory.mac
+++ b/test/test-store-trajectory.mac
@@ -1,0 +1,20 @@
+# minimal command set test
+# verbose
+/run/verbose 2
+/tracking/verbose 0
+
+# Enable trajectory storage
+/tracking/storeTrajectory 1
+
+# set default cut
+/run/setCut 3.0 cm
+
+# run init
+/run/initialize
+
+# lab depth [km.w.e.]
+/WLGD/generator/depth 5.89
+
+# start
+/run/beamOn 4
+


### PR DESCRIPTION
Initial runs showed large and increasing memory consumption by the application. Runs with valgrind could not pinpoint anything specific in WLGD code. Further investigation showed that memory increases occured with trajectory storage, likely due to the large number of trajectories that can potentially occur in a biased run, plus the use of G4Allocator's memory pool to manage this memory.

Only add a trajectory to a track if the user has requested storage via `/tracking/storeTrajectories`. Update EndOfEventAction to check for a valid pointer to the trajectory container before iterating over it.

This will lead to branches with null data in the output TTree, but this should be safe.

I'd recommend checking that this passes and is otherwise o.k., merge it, and then rebase #28 on top of the updated `master`. Can then see how the additional changes in #28 modify things further.

I'm not 100% sure this resolves everything that's causing increased memory use reported in #27 . Whilst it's clearly related to trajectory storage, it likely needs a further check here to make sure things are used in the right way and there are no leaks in this area of the code. I did try cleaning the allocators between events and could confirm these were reporting  zero usage after this, but this did not lead to an observable drop in the memory steady-state whilst running (or over two runs).