### PR TITLE
Provide UI command to export geometry to GDML file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 include(CTest)
 
 # Dependencies
-find_package(Geant4 10.6 REQUIRED ui_all vis_all)
+find_package(Geant4 10.6 REQUIRED gdml ui_all vis_all)
 
 # Build
 add_executable(warwick-legend

--- a/include/WLGDDetectorConstruction.hh
+++ b/include/WLGDDetectorConstruction.hh
@@ -22,6 +22,7 @@ public:
   G4double GetWorldSizeZ() { return fvertexZ; }  // inline
   G4double GetWorldExtent() { return fmaxrad; }  // --"--
   void     SetGeometry(const G4String& name);
+  void     ExportGeometry(const G4String& file);
   void     SetNeutronBiasFactor(G4double nf);
   void     SetMuonBiasFactor(G4double mf);
 

--- a/src/WLGDDetectorConstruction.cc
+++ b/src/WLGDDetectorConstruction.cc
@@ -6,6 +6,7 @@
 
 #include "G4Box.hh"
 #include "G4Cons.hh"
+#include "G4GDMLParser.hh"
 #include "G4GeometryManager.hh"
 #include "G4LogicalVolume.hh"
 #include "G4LogicalVolumeStore.hh"
@@ -37,7 +38,6 @@
 WLGDDetectorConstruction::WLGDDetectorConstruction()
 {
   DefineCommands();
-
   DefineMaterials();
 }
 
@@ -641,6 +641,12 @@ void WLGDDetectorConstruction::SetGeometry(const G4String& name)
   G4RunManager::GetRunManager()->ReinitializeGeometry();
 }
 
+void WLGDDetectorConstruction::ExportGeometry(const G4String& file)
+{
+  G4GDMLParser parser;
+  parser.Write(file);
+}
+
 void WLGDDetectorConstruction::SetNeutronBiasFactor(G4double nf) { fNeutronBias = nf; }
 
 void WLGDDetectorConstruction::SetMuonBiasFactor(G4double mf) { fMuonBias = mf; }
@@ -658,6 +664,15 @@ void WLGDDetectorConstruction::DefineCommands()
     .SetGuidance("alternative = NEEDS DESCRIPTION")
     .SetCandidates("baseline alternative")
     .SetStates(G4State_PreInit)
+    .SetToBeBroadcasted(false);
+
+  // GDML Export
+  fDetectorMessenger
+    ->DeclareMethod("exportGeometry", &WLGDDetectorConstruction::ExportGeometry)
+    .SetGuidance("Export current geometry to a GDML file")
+    .SetParameterName("filename", false)
+    .SetDefaultValue("wlgd.gdml")
+    .SetStates(G4State_Idle)
     .SetToBeBroadcasted(false);
 
   // Define bias operator command directory using generic messenger class

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -10,3 +10,11 @@ add_test(NAME change-bias COMMAND warwick-legend -m "${CMAKE_CURRENT_LIST_DIR}/t
 # 4. Check trajectory storage runs
 add_test(NAME trajectory-storage COMMAND warwick-legend -m "${CMAKE_CURRENT_LIST_DIR}/test-trajectory-storage.mac")
 
+# 5. Check gdml export runs
+# a. File output
+add_test(NAME gdml-export-run COMMAND warwick-legend -m "${CMAKE_CURRENT_LIST_DIR}/test-gdml-export-run.mac")
+# b. File existence (*not* validation)
+add_test(NAME gdml-export-exists
+  COMMAND ${CMAKE_COMMAND} -DGDML_FILE=${CMAKE_CURRENT_BINARY_DIR}/test-gdml-export.gdml
+                           -P "${CMAKE_CURRENT_LIST_DIR}/test-gdml-export-exists.cmake")
+set_property(TEST gdml-export-exists PROPERTY DEPENDS gdml-export-run)

--- a/test/test-gdml-export-exists.cmake
+++ b/test/test-gdml-export-exists.cmake
@@ -1,0 +1,26 @@
+# Usage:
+#  cmake -DGDML_FILE=/path/to/file.gdml -P test-gdml-export-exists.cmake
+#
+# Compare hash on input gdml file to an expected hash
+# - At present only checks that file exists and is not empty
+#   Known hashes could be used later to validate file
+#
+
+# Input Error checking
+if(NOT GDML_FILE)
+  message(FATAL_ERROR "no GDML_FILE argument passed")
+endif()
+
+if(NOT (EXISTS ${GDML_FILE}))
+  message(FATAL_ERROR "input file '${GDML_FILE}' does not exist")
+endif()
+
+# Compare hash of empty file to input file
+string(SHA1 NULL_HASH "")
+file(SHA1 "${GDML_FILE}" GDML_FILE_HASH)
+
+if(GDML_FILE_HASH STREQUAL NULL_HASH)
+  message(FATAL_ERROR "File '${GDML_FILE}' exists but is of zero length")
+endif()
+
+message(STATUS "${GDML_FILE_HASH} ${GDML_FILE}")

--- a/test/test-gdml-export-run.mac
+++ b/test/test-gdml-export-run.mac
@@ -1,0 +1,4 @@
+# Test that geometry can be exported to gdml
+/run/initialize
+/WLGD/detector/exportGeometry test-gdml-export.gdml
+


### PR DESCRIPTION
New member function in WLGDDetectorConstruction exports current, full geometry to a GDML output file. Bind this function to a UI command that takes the output file path as an argument.

Implement tests that run the command and then check that the output file exists and is non-zero length. No validation of the output is performed as yet.

This is a very minimal implementation and only allows export, not import, with `G4GDMLParser`s default behaviour. `G4GDMLParser` does supply its own UI commands, but these require holding an instance of it, and the commands appear in the `/persistency/gdml` directory, so not as clear. These would also connect up the import commands, which we'd need to think about as that would override the baseline/alternative, plus biasing/scoring etc. That can all be handled in GDML, or  DD4HEP, but these are for the longer term. This at least provides a way to get a GDML file to begin with!

There's no validation of the GDML output as yet as it's assumed to accurately represent what's programmed up in the code. Could provide a way to monitor changes though, as its diff/hash *should* be a reliable way to compare between different geometries or updates to them.   