### PR TITLE
More hit data

### DIFF
--- a/src/WLGDDetectorConstruction.cc
+++ b/src/WLGDDetectorConstruction.cc
@@ -118,7 +118,6 @@ void WLGDDetectorConstruction::ConstructSDandField()
     fSD.Put(det);
 
     auto* vertexFilter = new G4SDParticleFilter("vtxfilt");
-    // vertexFilter->add("neutron");  // neutrons in Ge of interest
     vertexFilter->addIon(32, 77);  // register 77Ge production
 
     auto* eprimitive = new WLGDPSEnergyDeposit("Edep");

--- a/src/WLGDDetectorConstruction.cc
+++ b/src/WLGDDetectorConstruction.cc
@@ -118,7 +118,7 @@ void WLGDDetectorConstruction::ConstructSDandField()
     fSD.Put(det);
 
     auto* vertexFilter = new G4SDParticleFilter("vtxfilt");
-    vertexFilter->add("neutron");  // neutrons in Ge of interest
+    // vertexFilter->add("neutron");  // neutrons in Ge of interest
     vertexFilter->addIon(32, 77);  // register 77Ge production
 
     auto* eprimitive = new WLGDPSEnergyDeposit("Edep");

--- a/src/WLGDPSEnergyDeposit.cc
+++ b/src/WLGDPSEnergyDeposit.cc
@@ -31,8 +31,6 @@ WLGDPSEnergyDeposit::~WLGDPSEnergyDeposit() = default;
 G4bool WLGDPSEnergyDeposit::ProcessHits(G4Step* aStep, G4TouchableHistory* /*unused*/)
 {
   G4double edep = aStep->GetTotalEnergyDeposit();
-//  if(edep == 0.)
-//    return false;  // not for zero edep
 
   edep *= aStep->GetPreStepPoint()->GetWeight();  // (Particle Weight)
   EvtMap->add(fCounter, edep);

--- a/src/WLGDPSEnergyDeposit.cc
+++ b/src/WLGDPSEnergyDeposit.cc
@@ -1,6 +1,7 @@
 // WLGDPSEnergyDeposit
 #include "WLGDPSEnergyDeposit.hh"
 #include "G4UnitsTable.hh"
+#include "G4ios.hh"
 
 ////////////////////////////////////////////////////////////////////////////////
 // Description:
@@ -34,6 +35,15 @@ G4bool WLGDPSEnergyDeposit::ProcessHits(G4Step* aStep, G4TouchableHistory* /*unu
   if(edep == 0.)
     return false;  // not for zero edep
 
+  // dummy print info on hit
+  G4cout << "energy scorer: particle name = " 
+         << aStep->GetTrack()->GetParticleDefinition()->GetParticleName() << G4endl;
+  G4cout << "lifetime: " 
+         << aStep->GetTrack()->GetParticleDefinition()->GetPDGLifeTime() << G4endl;
+  G4cout << "PDG: "
+         << aStep->GetTrack()->GetParticleDefinition()->GetPDGEncoding() << G4endl;
+
+  // end print info
   edep *= aStep->GetPreStepPoint()->GetWeight();  // (Particle Weight)
   EvtMap->add(fCounter, edep);
   fCounter++;

--- a/src/WLGDPSEnergyDeposit.cc
+++ b/src/WLGDPSEnergyDeposit.cc
@@ -1,7 +1,6 @@
 // WLGDPSEnergyDeposit
 #include "WLGDPSEnergyDeposit.hh"
 #include "G4UnitsTable.hh"
-#include "G4ios.hh"
 
 ////////////////////////////////////////////////////////////////////////////////
 // Description:
@@ -35,15 +34,6 @@ G4bool WLGDPSEnergyDeposit::ProcessHits(G4Step* aStep, G4TouchableHistory* /*unu
   if(edep == 0.)
     return false;  // not for zero edep
 
-  // dummy print info on hit
-  G4cout << "energy scorer: particle name = " 
-         << aStep->GetTrack()->GetParticleDefinition()->GetParticleName() << G4endl;
-  G4cout << "lifetime: " 
-         << aStep->GetTrack()->GetParticleDefinition()->GetPDGLifeTime() << G4endl;
-  G4cout << "PDG: "
-         << aStep->GetTrack()->GetParticleDefinition()->GetPDGEncoding() << G4endl;
-
-  // end print info
   edep *= aStep->GetPreStepPoint()->GetWeight();  // (Particle Weight)
   EvtMap->add(fCounter, edep);
   fCounter++;

--- a/src/WLGDPSEnergyDeposit.cc
+++ b/src/WLGDPSEnergyDeposit.cc
@@ -31,8 +31,8 @@ WLGDPSEnergyDeposit::~WLGDPSEnergyDeposit() = default;
 G4bool WLGDPSEnergyDeposit::ProcessHits(G4Step* aStep, G4TouchableHistory* /*unused*/)
 {
   G4double edep = aStep->GetTotalEnergyDeposit();
-  if(edep == 0.)
-    return false;  // not for zero edep
+//  if(edep == 0.)
+//    return false;  // not for zero edep
 
   edep *= aStep->GetPreStepPoint()->GetWeight();  // (Particle Weight)
   EvtMap->add(fCounter, edep);

--- a/src/WLGDPSLocation.cc
+++ b/src/WLGDPSLocation.cc
@@ -30,8 +30,8 @@ WLGDPSLocation::~WLGDPSLocation() = default;
 
 G4bool WLGDPSLocation::ProcessHits(G4Step* aStep, G4TouchableHistory* /*unused*/)
 {
-  if(aStep->GetTotalEnergyDeposit() == 0.)
-    return false;  // not for zero edep
+//  if(aStep->GetTotalEnergyDeposit() == 0.)
+//    return false;  // not for zero edep
 
   G4StepPoint*  preStepPoint = aStep->GetPreStepPoint();
   G4ThreeVector loc          = preStepPoint->GetPosition();  // location at track creation

--- a/src/WLGDPSLocation.cc
+++ b/src/WLGDPSLocation.cc
@@ -30,8 +30,6 @@ WLGDPSLocation::~WLGDPSLocation() = default;
 
 G4bool WLGDPSLocation::ProcessHits(G4Step* aStep, G4TouchableHistory* /*unused*/)
 {
-//  if(aStep->GetTotalEnergyDeposit() == 0.)
-//    return false;  // not for zero edep
 
   G4StepPoint*  preStepPoint = aStep->GetPreStepPoint();
   G4ThreeVector loc          = preStepPoint->GetPosition();  // location at track creation

--- a/src/WLGDPSTime.cc
+++ b/src/WLGDPSTime.cc
@@ -30,8 +30,8 @@ WLGDPSTime::~WLGDPSTime() = default;
 
 G4bool WLGDPSTime::ProcessHits(G4Step* aStep, G4TouchableHistory* /*unused*/)
 {
-  if(aStep->GetTotalEnergyDeposit() == 0.)
-    return false;  // not for zero edep
+//  if(aStep->GetTotalEnergyDeposit() == 0.)
+//    return false;  // not for zero edep
 
   // global time since start of event
   G4double tt = aStep->GetTrack()->GetGlobalTime();

--- a/src/WLGDPSTime.cc
+++ b/src/WLGDPSTime.cc
@@ -30,8 +30,6 @@ WLGDPSTime::~WLGDPSTime() = default;
 
 G4bool WLGDPSTime::ProcessHits(G4Step* aStep, G4TouchableHistory* /*unused*/)
 {
-//  if(aStep->GetTotalEnergyDeposit() == 0.)
-//    return false;  // not for zero edep
 
   // global time since start of event
   G4double tt = aStep->GetTrack()->GetGlobalTime();

--- a/src/WLGDPSTrackID.cc
+++ b/src/WLGDPSTrackID.cc
@@ -21,8 +21,6 @@ WLGDPSTrackID::~WLGDPSTrackID() = default;
 
 G4bool WLGDPSTrackID::ProcessHits(G4Step* aStep, G4TouchableHistory* /*unused*/)
 {
-//  if(aStep->GetTotalEnergyDeposit() == 0.)
-//    return false;  // not for zero edep
 
   G4int tid = aStep->GetTrack()->GetTrackID();
   EvtMap->add(fCounter, tid);

--- a/src/WLGDPSTrackID.cc
+++ b/src/WLGDPSTrackID.cc
@@ -21,8 +21,8 @@ WLGDPSTrackID::~WLGDPSTrackID() = default;
 
 G4bool WLGDPSTrackID::ProcessHits(G4Step* aStep, G4TouchableHistory* /*unused*/)
 {
-  if(aStep->GetTotalEnergyDeposit() == 0.)
-    return false;  // not for zero edep
+//  if(aStep->GetTotalEnergyDeposit() == 0.)
+//    return false;  // not for zero edep
 
   G4int tid = aStep->GetTrack()->GetTrackID();
   EvtMap->add(fCounter, tid);

--- a/src/WLGDPSTrackWeight.cc
+++ b/src/WLGDPSTrackWeight.cc
@@ -21,8 +21,8 @@ WLGDPSTrackWeight::~WLGDPSTrackWeight() = default;
 
 G4bool WLGDPSTrackWeight::ProcessHits(G4Step* aStep, G4TouchableHistory* /*unused*/)
 {
-  if(aStep->GetTotalEnergyDeposit() == 0.)
-    return false;  // not for zero edep
+//  if(aStep->GetTotalEnergyDeposit() == 0.)
+//    return false;  // not for zero edep
 
   // total weight since start of event
   G4double we = aStep->GetTrack()->GetWeight();

--- a/src/WLGDPSTrackWeight.cc
+++ b/src/WLGDPSTrackWeight.cc
@@ -21,8 +21,6 @@ WLGDPSTrackWeight::~WLGDPSTrackWeight() = default;
 
 G4bool WLGDPSTrackWeight::ProcessHits(G4Step* aStep, G4TouchableHistory* /*unused*/)
 {
-//  if(aStep->GetTotalEnergyDeposit() == 0.)
-//    return false;  // not for zero edep
 
   // total weight since start of event
   G4double we = aStep->GetTrack()->GetWeight();

--- a/warwick-legend.cc
+++ b/warwick-legend.cc
@@ -79,11 +79,6 @@ int main(int argc, char** argv)
 
   // -- set user physics list
   auto* physicsList = new Shielding;
-
-  // remove radioactive decay from list
-  // auto* removeFromList = new G4RadioactiveDecayPhysics();
-  // physicsList->RemovePhysics(removeFromList);
-
   // allow for thermal neutrons to find Ge
   auto* neutronCut  = new G4NeutronTrackingCut(1);
   neutronCut->SetTimeLimit(2.0 * CLHEP::ms);  // 2 milli sec limit

--- a/warwick-legend.cc
+++ b/warwick-legend.cc
@@ -79,7 +79,7 @@ int main(int argc, char** argv)
   // -- set user physics list
   auto* physicsList = new Shielding;
   auto* neutronCut  = new G4NeutronTrackingCut(1);
-  neutronCut->SetTimeLimit(1.0 * CLHEP::us);  // 1 micro sec limit
+  neutronCut->SetTimeLimit(1.0 * CLHEP::ms);  // 1 milli sec limit
   physicsList->RegisterPhysics(neutronCut);   // allow G4UserLimits
 
   // - Setup biasing, first for neutrons, again for muons

--- a/warwick-legend.cc
+++ b/warwick-legend.cc
@@ -86,8 +86,8 @@ int main(int argc, char** argv)
 
   // allow for thermal neutrons to find Ge
   auto* neutronCut  = new G4NeutronTrackingCut(1);
-  neutronCut->SetTimeLimit(1.0 * CLHEP::ms);  // 1 milli sec limit
-  physicsList->RegisterPhysics(neutronCut);   // allow G4UserLimits
+  neutronCut->SetTimeLimit(2.0 * CLHEP::ms);  // 2 milli sec limit
+  physicsList->RegisterPhysics(neutronCut);   // like in Gerda paper
 
   // - Setup biasing, first for neutrons, again for muons
   auto* biasingPhysics = new G4GenericBiasingPhysics();

--- a/warwick-legend.cc
+++ b/warwick-legend.cc
@@ -21,6 +21,7 @@
 #include "G4NeutronTrackingCut.hh"
 #include "G4Threading.hh"
 #include "G4UImanager.hh"
+#include "G4RadioactiveDecayPhysics.hh"
 #include "Shielding.hh"
 
 // us
@@ -78,6 +79,12 @@ int main(int argc, char** argv)
 
   // -- set user physics list
   auto* physicsList = new Shielding;
+
+  // remove radioactive decay from list
+  auto* removeFromList = new G4RadioactiveDecayPhysics();
+  physicsList->RemovePhysics(removeFromList);
+
+  // allow for thermal neutrons to find Ge
   auto* neutronCut  = new G4NeutronTrackingCut(1);
   neutronCut->SetTimeLimit(1.0 * CLHEP::ms);  // 1 milli sec limit
   physicsList->RegisterPhysics(neutronCut);   // allow G4UserLimits
@@ -96,6 +103,8 @@ int main(int argc, char** argv)
   biasingPhysics->Bias("mu-", pvec);  // bias particle and process
 
   physicsList->RegisterPhysics(biasingPhysics);
+
+  // finish physics list
   runManager->SetUserInitialization(physicsList);
 
   // -- Set user action initialization class, forward random seed

--- a/warwick-legend.cc
+++ b/warwick-legend.cc
@@ -81,8 +81,8 @@ int main(int argc, char** argv)
   auto* physicsList = new Shielding;
 
   // remove radioactive decay from list
-  auto* removeFromList = new G4RadioactiveDecayPhysics();
-  physicsList->RemovePhysics(removeFromList);
+  // auto* removeFromList = new G4RadioactiveDecayPhysics();
+  // physicsList->RemovePhysics(removeFromList);
 
   // allow for thermal neutrons to find Ge
   auto* neutronCut  = new G4NeutronTrackingCut(1);


### PR DESCRIPTION
Slight misnomer, my fault. That was the initial intention but it turns out that we already get the maximum information about the Ge77 production, with the energy scorer being rather redundant. Geant4 does not distinguish between Ge77 and its isomer, the neutron capture cross sections is a total, i.e. for both. That explains Fig. 4 in the Gerda paper where they have to discuss the split between ground-state and isomer production with measured cross sections.
In summary, this PR contains the removal of radioactive decay physics which isn't needed in this application and a more important relaxing of the neutron time cut to 2 milliseconds which is the upper limit from the Gerda paper. The latter leads to enhanced Ge77 production numbers due to allowing slower, more thermal neutrons.
This PR should probably bump up the version number since production runs could start from this, well sort of have already for testing.