### PR TITLE
[primary] larger primary vertex radius, entire hall.

### DIFF
--- a/src/WLGDDetectorConstruction.cc
+++ b/src/WLGDDetectorConstruction.cc
@@ -676,7 +676,7 @@ auto WLGDDetectorConstruction::SetupHallA() -> G4VPhysicalVolume*
   G4int    nofLayers      = 8;
 
   fvertexZ = (hallhheight + offset) * cm;
-  fmaxrad  = cryrad * cm;  // just 2 m radius
+  fmaxrad  = hallrad * cm;  // 8 m radius
 
   // Volumes for this geometry
 


### PR DESCRIPTION
This merely increases the primary vertex region to the entire hall such that muon flux and Ge-77 production rate converge. Has been used to validate the LNGS results from Wiesinger et al.
The previous primary vertex area was incomplete, i.e. too small.