### PR TITLE
[primary] alternative geometry needed suitable vertex surface

### DIFF
--- a/src/WLGDDetectorConstruction.cc
+++ b/src/WLGDDetectorConstruction.cc
@@ -258,7 +258,7 @@ auto WLGDDetectorConstruction::SetupAlternative() -> G4VPhysicalVolume*
     tankhside - outerwall - insulation - innerwall;  // cube side of LAr volume
 
   fvertexZ = (worldside - stone - 0.1) * cm;  // max vertex height
-  fmaxrad  = fvertexZ * cm;                   // max vertex circle radius
+  fmaxrad  = hallhside * cm;                   // max vertex circle radius
 
   // Volumes for this geometry
 


### PR DESCRIPTION
The alternative geometry needed a suitable vertex surface. The previous implementation left a far too large surface, loosing flux not compensated by area increase.
Now HallA, baseline and alternative geometries all perform as expected. Analysis and validation still to follow.